### PR TITLE
feat(relay): wire RELAY_HEARTBEAT_API_KEY/_SECRET env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,8 @@ services:
       - RELAY_INSTANCE_ID=relay-helium-1
       - RELAY_REQUIRE_ENCRYPTION=false
       - RELAY_HEARTBEAT_API_URL=http://heartbeat:9000
+      - RELAY_HEARTBEAT_API_KEY=${RELAY_HEARTBEAT_API_KEY:-rl_test_relay001}
+      - RELAY_HEARTBEAT_API_SECRET=${RELAY_HEARTBEAT_API_SECRET:-secret-for-test-key-001}
       - RELAY_CORE_API_URL=http://core:8080
       - RELAY_TENANTS_FILE=/app/tenants.json
       - RELAY_DATABASE_URL=postgresql://${PG_USER:-helium}:${PG_PASSWORD:-helium_demo_2026}@postgres:5432/${PG_DATABASE:-helium}


### PR DESCRIPTION
## Summary

- Adds two env vars to the `relay-api` service so Relay's `HeartBeatClient` can authenticate against HeartBeat's service-credential-gated endpoints (`/api/platform/transforma/config`, `/api/blobs/*`, `/api/dedup/*`, `/api/limits/*`, `/api/audit/log`, `/api/metrics/report`).
- Dev defaults match the plaintext comments in `helium-services/HeartBeat/databases/registry_seed.sql` (`rl_test_relay001` / `secret-for-test-key-001`); `${VAR:-default}` substitution means prod deployments override via `.env` without touching compose.

## Symptom this fixes

```
relay-api | Module cache load failed (degraded mode): HeartBeat rejected JWT on
relay-api | get_transforma_config: TOKEN_INVALID — Missing or invalid
relay-api | Authorization header. Expected: Bearer {api_key}:{api_secret}
relay-api | Module cache NOT loaded — external flow will return 503
```

`curl /relay/health` returned `module_cache: "not_loaded"`; HeartBeat's `api_credentials.last_used_at` was `NULL` for the Relay credential — Relay had never successfully authenticated.

## After the fix (verified on Abbey Mortgage demo EC2)

- `/relay/health` → `module_cache: "loaded"`
- `rl_test_relay001.last_used_at` populated on HeartBeat side
- Full ingestion flow passes end-to-end: write → dedup check → register → dedup record → Core download → status=processing → status=finalized, with SSE `blob.uploaded` + 2× `blob.status_changed` emitted to HeartBeat's event_ledger.

## Test plan

- [ ] `docker compose up -d --force-recreate relay-api`
- [ ] `curl http://<host>:8082/health` → `services.heartbeat=healthy`, `services.module_cache=loaded`
- [ ] Relay startup log no longer contains "Module cache NOT loaded"
- [ ] Upload a test file through Relay ingest → verify 200 and blob shows up in HeartBeat `/api/v1/heartbeat/blob/{uuid}/status`

## Notes

Related: `helium-services#8` — fixes a leading-slash path bug in `filesystem_client._object_path` that surfaced during the same E2E validation. That PR should land first or at the same time; without it, Core's blob download still 404s even with Relay credentials working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)