### PR TITLE
feat(relay): Phase 1b abuse middleware — rate limit + size cap + timeout + nonce replay

### DIFF
--- a/services/relay/src/api/app.py
+++ b/services/relay/src/api/app.py
@@ -103,6 +103,8 @@ def create_app(
             service_api_key=config.heartbeat_api_key,
             service_api_secret=config.heartbeat_api_secret,
             timeout_s=config.request_timeout_s,
+            cache_ttl_s=config.introspect_cache_ttl_s,
+            cache_max_entries=config.introspect_cache_max,
         )
         core = CoreClient(
             core_api_url=config.core_api_url,

--- a/services/relay/src/api/app.py
+++ b/services/relay/src/api/app.py
@@ -29,7 +29,13 @@ from ..errors import RelayError
 from ..services.bulk import BulkService
 from ..services.external import ExternalService
 from ..services.ingestion import IngestionService
-from .middleware import BodyCacheMiddleware, TraceIDMiddleware, relay_error_handler
+from .middleware import (
+    BodyCacheMiddleware,
+    RateLimitMiddleware,
+    RequestSafetyMiddleware,
+    TraceIDMiddleware,
+    relay_error_handler,
+)
 from .routes.health import router as health_router
 from .routes.ingest import router as ingest_router
 from .routes.internal import router as internal_router
@@ -104,13 +110,25 @@ def create_app(
             preview_timeout=config.preview_timeout_s,
         )
 
-        # Redis (rate limiting)
+        # Redis (rate limiting + nonce replay)
         redis_client = RedisClient(
             redis_url=config.redis_url,
             prefix=config.redis_prefix,
             default_limit=config.rate_limit_daily,
+            fail_open_burst=config.rate_limit_fail_open_burst,
         )
         await redis_client.connect()
+
+        # Tier-limits catalogue for Phase 1b rate limiter (spec §6.3).
+        # TODO: fetch from HB /api/admin/tier_limits once that endpoint ships.
+        # For now, use the spec-default table baked in — matches migration 007
+        # seed values in config.db.tier_limits.
+        rate_limits_by_tier = {
+            "test":       {"api_requests_per_minute": 30,   "api_requests_per_hour": 500},
+            "standard":   {"api_requests_per_minute": 100,  "api_requests_per_hour": 2000},
+            "pro":        {"api_requests_per_minute": 300,  "api_requests_per_hour": 10000},
+            "enterprise": {"api_requests_per_minute": 1000, "api_requests_per_hour": 50000},
+        }
 
         # Tenant config cache (full config from HeartBeat)
         config_cache = ConfigCache(heartbeat)
@@ -150,6 +168,7 @@ def create_app(
         app.state.introspect_client = introspect_client
         app.state.core = core
         app.state.redis = redis_client
+        app.state.rate_limits_by_tier = rate_limits_by_tier
         app.state.config_cache = config_cache
         app.state.module_cache = module_cache
         app.state.ingestion = ingestion
@@ -176,11 +195,21 @@ def create_app(
     )
 
     # Middleware (Starlette stacks: last added = outermost = runs first)
-    # 1. TraceIDMiddleware: inject X-Trace-ID (inner)
-    # 2. BodyCacheMiddleware: cache raw body so HMAC auth + form parsing
-    #    can both read it without "Stream consumed" errors (outer)
+    # Innermost → outermost:
+    #   TraceIDMiddleware      — inject X-Trace-ID (innermost)
+    #   BodyCacheMiddleware    — cache raw body for HMAC + form parsing
+    #   RateLimitMiddleware    — token-bucket per caller (spec §6)
+    #   RequestSafetyMiddleware — size cap + timeout (spec §8) (outermost)
+    # Rationale: reject too-large / timed-out requests BEFORE caching the
+    # body or consuming rate-limit tokens.
     app.add_middleware(TraceIDMiddleware)
     app.add_middleware(BodyCacheMiddleware)
+    app.add_middleware(RateLimitMiddleware)
+    app.add_middleware(
+        RequestSafetyMiddleware,
+        max_request_bytes=config.max_request_bytes,
+        request_timeout_s=config.handler_timeout_s,
+    )
 
     # Error handlers
     app.add_exception_handler(RelayError, relay_error_handler)

--- a/services/relay/src/api/deps.py
+++ b/services/relay/src/api/deps.py
@@ -29,6 +29,7 @@ from ..errors import (
     HeartBeatUnavailableError,
     InvalidAPIKeyError,
     JWTRejectedError,
+    ReplayDetectedError,
 )
 from .caller_context import CallerContext
 
@@ -87,6 +88,11 @@ async def _verify_hmac(
 
     Preserves the existing behaviour: timestamp window, api_key lookup,
     signature verification over the raw body cached by BodyCacheMiddleware.
+
+    Spec §7 — nonce replay protection: if the caller supplies X-Nonce,
+    it MUST be single-use within the configured TTL (default 600s).
+    Missing X-Nonce is accepted with a WARN log for backward compat with
+    pre-Phase-1b clients; enforcement becomes mandatory in Phase 2.
     """
     body = getattr(request.state, "raw_body", None)
     if body is None:
@@ -103,6 +109,29 @@ async def _verify_hmac(
         api_key_secrets=api_key_secrets,
         trace_id=trace_id,
     )
+
+    # Nonce replay check — only when client opts in by sending X-Nonce.
+    nonce = request.headers.get("x-nonce")
+    if nonce:
+        redis = getattr(request.app.state, "redis", None)
+        cfg: RelayConfig = request.app.state.config
+        ttl_s = getattr(cfg, "nonce_ttl_s", 600)
+        if redis is not None:
+            claimed = await redis.nonce_claim(nonce, ttl_s=ttl_s)
+            if not claimed:
+                logger.warning(
+                    f"Nonce replay rejected api_key={x_api_key[:8]}... "
+                    f"nonce={nonce[:12]}...",
+                    extra={"trace_id": trace_id},
+                )
+                raise ReplayDetectedError(nonce=nonce)
+    else:
+        logger.info(
+            f"HMAC request without X-Nonce api_key={x_api_key[:8]}... — "
+            "accepted for backward compat; clients should migrate to "
+            "sending a unique X-Nonce per request (spec §7).",
+            extra={"trace_id": trace_id},
+        )
 
     tenant_id = _tenant_id_for_api_key(request, x_api_key)
     return CallerContext(

--- a/services/relay/src/api/deps.py
+++ b/services/relay/src/api/deps.py
@@ -60,6 +60,25 @@ def get_external_service(request: Request) -> Any:
 
 # ── Auth dispatcher ──────────────────────────────────────────────────────
 
+# Per Keel HANDOFF_RELAY_JWT_INTROSPECT.md §2 and the HB-team response doc
+# (RELAY_JWT_INTROSPECT_HB_RESPONSE.md §2.1), the introspect call must pass
+# required_permission so HB enforces the permission check uniformly. The
+# mapping below defines per-route permission names; routes not listed get
+# no permission check (back-compat with pre-Phase-1b HMAC paths that never
+# enforced permissions).
+_ROUTE_REQUIRED_PERMISSIONS = (
+    ("/api/ingest",        "blob.upload"),
+    ("/api/bulk/preview",  "blob.upload"),
+)
+
+
+def _required_permission_for_path(path: str) -> Optional[str]:
+    for prefix, perm in _ROUTE_REQUIRED_PERMISSIONS:
+        if path.startswith(prefix):
+            return perm
+    return None
+
+
 def _tenant_id_for_api_key(request: Request, api_key: str) -> str:
     """
     Resolve tenant_id from an api_key via the tenants.json registry.
@@ -206,6 +225,10 @@ async def _verify_user_jwt(
 
     Never validates locally (§5.1). If HeartBeat is unreachable, raises
     AuthUpstreamUnavailableError → 502 (fail closed per §2.4).
+
+    Passes ``required_permission`` based on request path (per Keel spec §4.1
+    step 5). /api/ingest requires ``blob.upload``; other routes either set
+    their own required permission via app state or omit (back-compat).
     """
     introspect_client = getattr(request.app.state, "introspect_client", None)
     if introspect_client is None:
@@ -214,10 +237,12 @@ async def _verify_user_jwt(
         )
 
     trace_id = getattr(request.state, "trace_id", "") or ""
+    required_permission = _required_permission_for_path(request.url.path)
     try:
         result = await introspect_client.introspect(
             jwt_token=jwt_token,
             trace_id=trace_id,
+            required_permission=required_permission,
         )
     except HeartBeatUnavailableError as e:
         raise AuthUpstreamUnavailableError(str(e)) from e

--- a/services/relay/src/api/middleware.py
+++ b/services/relay/src/api/middleware.py
@@ -4,11 +4,17 @@ API Middleware
 TraceIDMiddleware: Adds X-Trace-ID to every request/response.
 BodyCacheMiddleware: Pre-reads and caches raw body so both HMAC auth and
                      form parsing can access it without "Stream consumed" errors.
+RateLimitMiddleware: Token-bucket rate limit per caller, per window
+                     (Phase 1b, spec §6).
+RequestSafetyMiddleware: Size cap + handler timeout (Phase 1b, spec §8).
 relay_error_handler: Catches RelayError and returns structured JSON.
 """
 
+import asyncio
+import base64
+import json
 import logging
-from typing import Any, Callable
+from typing import Any, Callable, Dict, Optional, Tuple
 
 from uuid6 import uuid7
 
@@ -16,9 +22,83 @@ from fastapi import Request
 from fastapi.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
-from ..errors import RelayError
+from ..errors import RelayError, RequestTooLargeError, RequestTimeoutError
 
 logger = logging.getLogger(__name__)
+
+
+# Endpoint → token cost (spec §6.5). Paths matched by startswith.
+# 0 = never rate-limited (deployment liveness / scrape endpoints).
+ENDPOINT_WEIGHTS: Tuple[Tuple[str, int], ...] = (
+    ("/health", 0),
+    ("/metrics", 0),
+    ("/api/ingest", 5),
+    ("/api/bulk/preview", 10),
+)
+DEFAULT_WEIGHT = 1
+
+
+def _endpoint_weight(path: str) -> int:
+    for prefix, weight in ENDPOINT_WEIGHTS:
+        if path.startswith(prefix):
+            return weight
+    return DEFAULT_WEIGHT
+
+
+def _unsafe_decode_jwt_payload(token: str) -> Dict[str, Any]:
+    """
+    Decode a JWT payload WITHOUT verifying the signature.
+
+    Used only for rate-limit keying — the auth dispatcher still verifies
+    the token via HeartBeat introspect before the request reaches a
+    handler. If the payload is malformed we return {} and the middleware
+    falls back to a token-hash key.
+    """
+    parts = token.split(".")
+    if len(parts) != 3:
+        return {}
+    try:
+        padding = "=" * (-len(parts[1]) % 4)
+        return json.loads(base64.urlsafe_b64decode(parts[1] + padding))
+    except Exception:
+        return {}
+
+
+def _caller_key_from_request(scope: Scope) -> str:
+    """
+    Derive rate-limit caller key from raw request headers (no auth call).
+
+    Keying rules (spec §6.1):
+      - HMAC path  → api_key
+      - Service creds Bearer api_key:api_secret → api_key
+      - User JWT Bearer <jwt> → tenant_id claim (fallback: sub, then token[:16])
+      - Anonymous → ip:<client_ip>
+    """
+    headers = {k.decode("latin-1").lower(): v.decode("latin-1")
+               for k, v in scope.get("headers", [])}
+
+    if "x-api-key" in headers and "x-signature" in headers:
+        return f"key:{headers['x-api-key']}"
+
+    auth = headers.get("authorization", "")
+    if auth.lower().startswith("bearer "):
+        token = auth[7:].strip()
+        if ":" in token and "." not in token:
+            api_key = token.split(":", 1)[0]
+            return f"key:{api_key}"
+        if token:
+            payload = _unsafe_decode_jwt_payload(token)
+            tid = payload.get("tenant_id") or payload.get("tid")
+            if tid:
+                return f"tenant:{tid}"
+            sub = payload.get("sub")
+            if sub:
+                return f"user:{sub}"
+            return f"jwt:{token[:16]}"
+
+    client = scope.get("client")
+    ip = client[0] if client else "unknown"
+    return f"ip:{ip}"
 
 
 class BodyCacheMiddleware:
@@ -103,6 +183,235 @@ class TraceIDMiddleware:
             await send(message)
 
         await self.app(scope, receive, send_with_trace)
+
+
+class RateLimitMiddleware:
+    """
+    Token-bucket rate limiter (spec §6).
+
+    Runs BEFORE auth so abuse is rejected cheaply. Keys per caller derived
+    from raw headers (api_key or tenant_id from unverified JWT payload).
+
+    Checks per-minute and per-hour buckets. On a reject, returns 429 with
+    Retry-After + X-RateLimit-* headers. On allow, adds X-RateLimit-*
+    response headers for the caller's remaining budget.
+
+    Tier-aware limits come from ``app.state.rate_limits_by_tier`` which is
+    populated at startup from HB ``tier_limits``. For this phase every
+    caller is treated as ``standard``; a per-caller tier resolver is a
+    Phase 2 enhancement.
+    """
+
+    def __init__(self, app: ASGIApp):
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        cost = _endpoint_weight(path)
+
+        if cost == 0:
+            await self.app(scope, receive, send)
+            return
+
+        # Late import to avoid a cycle at module load
+        app_state = scope.get("app").state  # type: ignore[attr-defined]
+        redis = getattr(app_state, "redis", None)
+        if redis is None:
+            # Rate-limit storage not configured — spec §6.6 fail-open.
+            await self.app(scope, receive, send)
+            return
+
+        tier_limits = getattr(app_state, "rate_limits_by_tier", {}) or {}
+        # Everyone gets "standard" in Phase 1b. Per-caller tier resolver
+        # is a Phase 2 enhancement — see spec §6.3.
+        limits = tier_limits.get("standard") or {
+            "api_requests_per_minute": 100,
+            "api_requests_per_hour": 2000,
+        }
+
+        caller_key = _caller_key_from_request(scope)
+        per_minute_cap = int(limits.get("api_requests_per_minute") or 0)
+        per_hour_cap = int(limits.get("api_requests_per_hour") or 0)
+
+        per_minute = await redis.token_bucket_check(
+            caller_key, "per_minute", per_minute_cap, cost=cost,
+        )
+        per_hour = await redis.token_bucket_check(
+            caller_key, "per_hour", per_hour_cap, cost=cost,
+        )
+
+        if not per_minute.allowed or not per_hour.allowed:
+            await self._send_429(send, per_minute, per_hour, caller_key, path)
+            return
+
+        rl_headers = _rate_limit_headers(per_minute, per_hour)
+
+        async def send_with_headers(message: Message):
+            if message["type"] == "http.response.start":
+                headers = list(message.get("headers", []))
+                headers.extend(rl_headers)
+                message = {**message, "headers": headers}
+            await send(message)
+
+        await self.app(scope, receive, send_with_headers)
+
+    async def _send_429(
+        self, send: Send,
+        per_minute: "Any", per_hour: "Any",
+        caller_key: str, path: str,
+    ):
+        import time as _time
+        now = int(_time.time())
+        # Retry-After uses whichever window blocked
+        retry_after = 1
+        if not per_minute.allowed:
+            retry_after = max(1, per_minute.reset_epoch - now)
+        elif not per_hour.allowed:
+            retry_after = max(1, per_hour.reset_epoch - now)
+
+        logger.warning(
+            f"rate_limit_exceeded caller={caller_key} path={path} "
+            f"per_minute={per_minute.allowed} per_hour={per_hour.allowed}"
+        )
+
+        body = json.dumps({
+            "status": "error",
+            "error_code": "RATE_LIMIT_EXCEEDED",
+            "message": (
+                "Rate limit exceeded. Retry after the Retry-After interval."
+            ),
+            "details": [{
+                "window": "per_minute" if not per_minute.allowed else "per_hour",
+                "retry_after_seconds": str(retry_after),
+            }],
+        }).encode("utf-8")
+
+        headers = [
+            (b"content-type", b"application/json"),
+            (b"content-length", str(len(body)).encode("ascii")),
+            (b"retry-after", str(retry_after).encode("ascii")),
+        ]
+        headers.extend(_rate_limit_headers(per_minute, per_hour))
+
+        await send({
+            "type": "http.response.start",
+            "status": 429,
+            "headers": headers,
+        })
+        await send({
+            "type": "http.response.body",
+            "body": body,
+        })
+
+
+def _rate_limit_headers(per_minute, per_hour):
+    """Build X-RateLimit-* response header list (spec §6.4)."""
+    return [
+        (b"x-ratelimit-limit-minute", str(per_minute.limit).encode("ascii")),
+        (b"x-ratelimit-remaining-minute", str(per_minute.remaining).encode("ascii")),
+        (b"x-ratelimit-reset-minute", str(per_minute.reset_epoch).encode("ascii")),
+        (b"x-ratelimit-limit-hour", str(per_hour.limit).encode("ascii")),
+        (b"x-ratelimit-remaining-hour", str(per_hour.remaining).encode("ascii")),
+        (b"x-ratelimit-reset-hour", str(per_hour.reset_epoch).encode("ascii")),
+    ]
+
+
+class RequestSafetyMiddleware:
+    """
+    Early request safety checks (spec §8).
+
+    - Size cap: reject requests with ``Content-Length`` greater than
+      ``max_request_bytes`` with 413 before any handler runs. Requests
+      without Content-Length (chunked) are allowed through — uvicorn
+      enforces a separate h11 limit.
+    - Timeout: wrap the downstream ASGI call in ``asyncio.wait_for`` at
+      ``request_timeout_s`` seconds, returning 504 on timeout. Prevents
+      slow-loris and runaway-handler hangs.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        max_request_bytes: int = 52_428_800,  # 50 MB
+        request_timeout_s: int = 30,
+    ):
+        self.app = app
+        self.max_request_bytes = max_request_bytes
+        self.request_timeout_s = request_timeout_s
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        content_length_raw = self._header_value(scope, b"content-length")
+        if content_length_raw is not None:
+            try:
+                content_length = int(content_length_raw)
+            except ValueError:
+                content_length = None
+            if (content_length is not None
+                    and content_length > self.max_request_bytes):
+                await self._send_error(
+                    send, 413, "REQUEST_TOO_LARGE",
+                    f"Request body {content_length} bytes exceeds the "
+                    f"{self.max_request_bytes}-byte limit.",
+                )
+                return
+
+        try:
+            await asyncio.wait_for(
+                self.app(scope, receive, send),
+                timeout=self.request_timeout_s,
+            )
+        except asyncio.TimeoutError:
+            # Handler may have started streaming a response. send() will raise
+            # if the response has already started — in that case we cannot do
+            # anything except log.
+            try:
+                await self._send_error(
+                    send, 504, "REQUEST_TIMEOUT",
+                    f"Request exceeded {self.request_timeout_s}s timeout.",
+                )
+            except Exception:
+                logger.error(
+                    "Timeout after response started — cannot emit 504.",
+                )
+
+    @staticmethod
+    def _header_value(scope: Scope, name: bytes) -> Optional[str]:
+        name_lower = name.lower()
+        for k, v in scope.get("headers", []):
+            if k.lower() == name_lower:
+                try:
+                    return v.decode("latin-1")
+                except Exception:
+                    return None
+        return None
+
+    @staticmethod
+    async def _send_error(send: Send, status: int, code: str, message: str):
+        body = json.dumps({
+            "status": "error",
+            "error_code": code,
+            "message": message,
+        }).encode("utf-8")
+        await send({
+            "type": "http.response.start",
+            "status": status,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode("ascii")),
+            ],
+        })
+        await send({
+            "type": "http.response.body",
+            "body": body,
+        })
 
 
 async def relay_error_handler(request: Request, exc: RelayError) -> JSONResponse:

--- a/services/relay/src/api/routes/ingest.py
+++ b/services/relay/src/api/routes/ingest.py
@@ -19,9 +19,11 @@ Headers:
     Authorization — Bearer JWT (optional, forwarded to HeartBeat/Core)
 """
 
+import asyncio
+import hashlib
 import json
 import logging
-from typing import Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
 
@@ -34,6 +36,64 @@ from ...services.external import ExternalService
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _audit_file_hash(files: List[Tuple[str, bytes]]) -> str:
+    """sha256 over the concatenated file bytes — matches audit spec §6.2."""
+    h = hashlib.sha256()
+    for _, data in files:
+        h.update(data)
+    return h.hexdigest()
+
+
+async def _emit_ingest_audit(
+    request: Request,
+    ctx: CallerContext,
+    trace_id: str,
+    call_type: str,
+    queue_id: str,
+    data_uuid: str,
+    filenames: List[str],
+    file_count: int,
+    total_size_bytes: int,
+    file_hash: str,
+    meta: Dict[str, Any],
+) -> None:
+    """
+    Emit file.ingested audit event (Keel spec §6). Fire-and-forget — never
+    blocks the ingest response. HeartBeatClient.audit_log already logs
+    WARN-level on failure.
+    """
+    try:
+        heartbeat = request.app.state.heartbeat
+        source_id = request.headers.get("x-source-id", "")
+        user_trace_id = request.headers.get("x-user-trace-id", meta.get("user_trace_id", ""))
+
+        await heartbeat.audit_log(
+            service="relay",
+            event_type="file.ingested",
+            user_id=(ctx.identifier if ctx.is_user else None),
+            details={
+                "queue_id": queue_id,
+                "data_uuid": data_uuid,
+                "file_hash": file_hash,
+                "file_count": file_count,
+                "caller_type": call_type,
+                "actor_type": ctx.actor_type,
+                "tenant_id": ctx.tenant_id,
+                "source_id": source_id or None,
+                "user_trace_id": user_trace_id or None,
+                "filenames": filenames,
+                "total_size_bytes": total_size_bytes,
+            },
+        )
+    except Exception as e:
+        # audit_log swallows most errors already — this catches anything
+        # unexpected (e.g. app.state.heartbeat missing in tests) so it
+        # cannot break the upload.
+        logger.warning(
+            f"[{trace_id}] emit_ingest_audit suppressed exception: {e}"
+        )
 
 
 @router.post(
@@ -132,6 +192,11 @@ async def ingest(
         data = await f.read()
         file_tuples.append((f.filename or "unknown", data))
 
+    # Compute these once — shared across both flows' audit emission
+    filenames_list = [f for f, _ in file_tuples]
+    total_size_bytes = sum(len(d) for _, d in file_tuples)
+    concat_hash = _audit_file_hash(file_tuples)
+
     if call_type == "external":
         # External flow: ingest → IRN/QR
         external_svc: ExternalService = request.app.state.external_service
@@ -150,6 +215,13 @@ async def ingest(
             metadata=meta,
             jwt_token=jwt_token,
         )
+        # Audit: fire-and-forget, does not block response
+        asyncio.create_task(_emit_ingest_audit(
+            request, ctx, trace_id, "external",
+            result.ingest.queue_id, result.ingest.data_uuid,
+            filenames_list, result.ingest.file_count,
+            total_size_bytes, concat_hash, meta,
+        ))
         return IngestResponse(
             status=result.status,
             data_uuid=result.ingest.data_uuid,
@@ -174,6 +246,12 @@ async def ingest(
             metadata=meta,
             jwt_token=jwt_token,
         )
+        asyncio.create_task(_emit_ingest_audit(
+            request, ctx, trace_id, "bulk",
+            result.ingest.queue_id, result.ingest.data_uuid,
+            filenames_list, result.ingest.file_count,
+            total_size_bytes, concat_hash, meta,
+        ))
         return IngestResponse(
             status=result.status,
             data_uuid=result.ingest.data_uuid,

--- a/services/relay/src/clients/introspect.py
+++ b/services/relay/src/clients/introspect.py
@@ -3,17 +3,27 @@ HeartBeat introspect client.
 
 Per BACKEND_SERVICE_AUTH_AND_ABUSE_SPEC.md §3.1 and §4, backend services
 verify user JWTs by calling POST /api/auth/introspect on HeartBeat. This
-module wraps that call with the exact request/response shape, a small
-cache hit (single-request only, never cross-request), and the error-code
-→ HTTP status mapping defined in the spec.
+module wraps that call with the exact request/response shape and the
+error-code → HTTP status mapping defined in the spec.
+
+Per Keel HANDOFF_RELAY_JWT_INTROSPECT.md §5 + HELIUM_AUTH_SPEC.md §8.7,
+introspect results are cached for 30 s keyed by JWT jti claim. This is
+critical during bulk upload bursts where the same JWT would otherwise
+trigger an introspect call per file. Negative results (active=false)
+are cached at the same key so a revoked-JWT spammer doesn't hammer HB.
 
 No local JWT validation happens here. The raw JWT is handed to HeartBeat;
 HeartBeat is the sole source of truth for identity (spec §5.1).
 """
 
+import asyncio
+import base64
+import json
 import logging
+import time
+from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 import httpx
 
@@ -24,6 +34,28 @@ from ..errors import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_jti(jwt_token: str) -> Optional[str]:
+    """
+    Pull the `jti` claim from a JWT payload WITHOUT verifying the signature.
+
+    Used only for cache-keying. Signature verification happens on the HB
+    side when the token is introspected, so a spoofed jti here would just
+    force a cache miss on the real token — no security impact.
+    Returns None for malformed tokens (caller falls back to the full-token
+    hash as a cache key).
+    """
+    parts = jwt_token.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        padding = "=" * (-len(parts[1]) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(parts[1] + padding))
+        jti = payload.get("jti")
+        return str(jti) if jti else None
+    except Exception:
+        return None
 
 
 @dataclass
@@ -62,15 +94,21 @@ class IntrospectResult:
         )
 
 
-# Spec §3.1 error_code → (HTTP status, Relay error class)
+# Spec §3.1 + Keel HANDOFF_RELAY_JWT_INTROSPECT §4.1 error_code → (HTTP status, Relay error code)
+# Keel spec uses STEP_UP_REQUIRED (underscore between STEP and UP); BACKEND_SERVICE_AUTH_AND_ABUSE_SPEC
+# §3.1 used STEPUP_REQUIRED. Accept both for compatibility during migration.
 _ERROR_HTTP_MAP = {
-    "TOKEN_INVALID":   (401, "TOKEN_INVALID"),
-    "TOKEN_EXPIRED":   (401, "TOKEN_EXPIRED"),
-    "SESSION_EXPIRED": (401, "SESSION_EXPIRED"),
-    "DEVICE_MISMATCH": (401, "DEVICE_MISMATCH"),
-    "PERMISSION_DENIED": (403, "PERMISSION_DENIED"),
-    "STEPUP_REQUIRED": (403, "STEPUP_REQUIRED"),
-    "ACCOUNT_LOCKED":  (423, "ACCOUNT_LOCKED"),
+    "TOKEN_INVALID":        (401, "TOKEN_INVALID"),
+    "TOKEN_EXPIRED":        (401, "TOKEN_EXPIRED"),
+    "TOKEN_REVOKED":        (401, "TOKEN_REVOKED"),
+    "SESSION_EXPIRED":      (401, "SESSION_EXPIRED"),
+    "PERMISSIONS_CHANGED":  (401, "PERMISSIONS_CHANGED"),
+    "FIRST_RUN_REQUIRED":   (401, "FIRST_RUN_REQUIRED"),
+    "DEVICE_MISMATCH":      (401, "DEVICE_MISMATCH"),
+    "PERMISSION_DENIED":    (403, "PERMISSION_DENIED"),
+    "STEPUP_REQUIRED":      (401, "STEP_UP_REQUIRED"),
+    "STEP_UP_REQUIRED":     (401, "STEP_UP_REQUIRED"),
+    "ACCOUNT_LOCKED":       (423, "ACCOUNT_LOCKED"),
 }
 
 
@@ -80,6 +118,13 @@ class IntrospectClient:
 
     Uses the service's own api_key:api_secret to authenticate the introspect
     call itself (spec §3.1). The JWT being introspected rides in the JSON body.
+
+    Carries a 30 s LRU cache keyed by JWT `jti` claim (Keel spec §5). Both
+    positive (active=true) and negative (active=false) results are cached at
+    the same key. Invalidation happens on TTL expiry only — a revoked token
+    that's already cached will continue to return `active=false` for up to
+    30 s; a revocation is therefore 30 s-latent in the worst case (same as
+    spec HELIUM_AUTH_SPEC §8.7 allowed window).
     """
 
     def __init__(
@@ -88,12 +133,65 @@ class IntrospectClient:
         service_api_key: str,
         service_api_secret: str,
         timeout_s: float = 5.0,
+        cache_ttl_s: float = 30.0,
+        cache_max_entries: int = 10_000,
     ):
         self._url = heartbeat_url.rstrip("/") + "/api/auth/introspect"
         self._service_api_key = service_api_key
         self._service_api_secret = service_api_secret
         self._timeout_s = timeout_s
         self._http: Optional[httpx.AsyncClient] = None
+
+        # Cache: OrderedDict for LRU, entries are (expires_at, result_or_error)
+        # where result_or_error is either IntrospectResult (positive) or a
+        # tuple (JWTRejectedError) for negative cache. Locking via a dedicated
+        # asyncio.Lock keeps concurrent cache access safe.
+        self._cache_ttl_s = cache_ttl_s
+        self._cache_max = cache_max_entries
+        self._cache: "OrderedDict[str, Tuple[float, Any]]" = OrderedDict()
+        self._cache_lock = asyncio.Lock()
+
+        # Metrics (best-effort, for observability)
+        self._cache_hits = 0
+        self._cache_misses = 0
+
+    # ── Cache helpers ──────────────────────────────────────────────────
+
+    async def _cache_get(self, key: str) -> Optional[Any]:
+        """Return cached value if present AND non-expired; otherwise None."""
+        async with self._cache_lock:
+            entry = self._cache.get(key)
+            if entry is None:
+                self._cache_misses += 1
+                return None
+            expires_at, value = entry
+            if time.time() >= expires_at:
+                # Expired — remove + miss
+                self._cache.pop(key, None)
+                self._cache_misses += 1
+                return None
+            # Move to end for LRU
+            self._cache.move_to_end(key)
+            self._cache_hits += 1
+            return value
+
+    async def _cache_put(self, key: str, value: Any) -> None:
+        """Store value with current TTL. Evicts oldest if over max."""
+        async with self._cache_lock:
+            expires_at = time.time() + self._cache_ttl_s
+            self._cache[key] = (expires_at, value)
+            self._cache.move_to_end(key)
+            while len(self._cache) > self._cache_max:
+                self._cache.popitem(last=False)
+
+    def cache_stats(self) -> Dict[str, int]:
+        """Best-effort metrics for /metrics scrape or health diagnostics."""
+        return {
+            "hits": self._cache_hits,
+            "misses": self._cache_misses,
+            "size": len(self._cache),
+            "max": self._cache_max,
+        }
 
     def _client(self) -> httpx.AsyncClient:
         if self._http is None:
@@ -111,6 +209,7 @@ class IntrospectClient:
         trace_id: str = "",
         required_permission: Optional[str] = None,
         required_within_seconds: Optional[int] = None,
+        bypass_cache: bool = False,
     ) -> IntrospectResult:
         """
         Verify a user JWT against HeartBeat.
@@ -118,12 +217,33 @@ class IntrospectClient:
         Returns IntrospectResult on active=true.
         Raises mapped Relay errors on active=false per spec §3.1.
         Raises HeartBeatUnavailableError if HB is unreachable or returns 5xx.
+
+        Cache: keyed by JWT jti + required_permission. A cache hit returns the
+        cached value directly without an HB call. A cache hit of a negative
+        result re-raises the original JWTRejectedError. ``bypass_cache=True``
+        forces a fresh introspect (used by the /health probe).
         """
         if not self._service_api_key or not self._service_api_secret:
             raise AuthenticationFailedError(
                 "Relay has no HeartBeat service credentials configured — "
                 "cannot introspect user JWTs. Check RELAY_HEARTBEAT_API_KEY/_SECRET."
             )
+
+        # Cache lookup — jti + required_permission so a token that passes with
+        # one permission but fails with another doesn't share a cache slot.
+        cache_key: Optional[str] = None
+        if not bypass_cache:
+            jti = _extract_jti(jwt_token)
+            if jti:
+                cache_key = f"{jti}|{required_permission or ''}"
+                cached = await self._cache_get(cache_key)
+                if cached is not None:
+                    if isinstance(cached, IntrospectResult):
+                        return cached
+                    if isinstance(cached, JWTRejectedError):
+                        raise cached
+                    # Unknown cached shape — drop it, fall through to HTTP
+                    logger.warning(f"Unexpected cache shape: {type(cached)}")
 
         auth_header = f"Bearer {self._service_api_key}:{self._service_api_secret}"
         headers = {
@@ -193,10 +313,21 @@ class IntrospectClient:
                 f"JWT rejected by HeartBeat: {code} — {result.message}",
                 extra={"trace_id": trace_id},
             )
-            raise JWTRejectedError(
+            err = JWTRejectedError(
                 error_code=relay_code,
                 message=result.message or "Token not active",
                 status_code=http_status,
             )
+            # Negative cache: store the error so repeat calls with the same
+            # token return fast without hitting HB. Spec §5 intent — a
+            # caller hammering with a revoked token shouldn't shovel load
+            # onto HB. 30 s matches positive TTL.
+            if cache_key is not None:
+                await self._cache_put(cache_key, err)
+            raise err
+
+        # Positive cache
+        if cache_key is not None:
+            await self._cache_put(cache_key, result)
 
         return result

--- a/services/relay/src/clients/redis_client.py
+++ b/services/relay/src/clients/redis_client.py
@@ -1,22 +1,78 @@
 """
 Redis Client for Rate Limiting
 
-Provides atomic rate limiting using Redis INCR + EXPIRE.
-Graceful degradation: if Redis is unavailable, all requests are allowed.
+Provides atomic rate limiting using Redis INCR + EXPIRE (legacy daily) and a
+Lua-backed token bucket (Phase 1b per-minute / per-hour) plus nonce-replay
+protection (SETNX) for the HMAC path.
 
-This is the ONLY Redis consumer in Relay. Dedup stays with HeartBeat.
-Blob storage stays with HeartBeat. Only rate limiting uses Redis directly.
+Graceful degradation: if Redis is unavailable, all requests are allowed at a
+bounded burst cap (spec §6.6) — this service is ingestion-critical, failing
+closed would wedge the platform for every caller on a Redis blip.
+
+This is the ONLY Redis consumer in Relay. Dedup stays with HeartBeat. Blob
+storage stays with HeartBeat. Only rate limiting + nonce replay use Redis
+directly.
 
 Does NOT inherit BaseClient — HTTP retry logic doesn't apply to Redis
 (sub-millisecond atomic ops, not multi-second HTTP round-trips).
 """
 
 import logging
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+
+# Lua script for atomic token-bucket refill + consume.
+#
+# KEYS[1] = bucket hash key
+# ARGV[1] = capacity           (int, max tokens)
+# ARGV[2] = refill_per_second  (float, tokens/sec)
+# ARGV[3] = cost               (int, tokens this request)
+# ARGV[4] = now                (float, epoch seconds)
+# ARGV[5] = bucket_ttl         (int, seconds of idle before Redis evicts)
+#
+# Returns: {allowed:int(0/1), remaining:int, reset_epoch:int}
+#   reset_epoch = estimated time bucket will be full again
+_TOKEN_BUCKET_LUA = """
+local key = KEYS[1]
+local capacity = tonumber(ARGV[1])
+local refill = tonumber(ARGV[2])
+local cost = tonumber(ARGV[3])
+local now = tonumber(ARGV[4])
+local ttl = tonumber(ARGV[5])
+
+local bucket = redis.call('HMGET', key, 'tokens', 'last_refill')
+local tokens = tonumber(bucket[1])
+local last_refill = tonumber(bucket[2])
+if tokens == nil then
+  tokens = capacity
+  last_refill = now
+end
+
+local elapsed = math.max(0, now - last_refill)
+tokens = math.min(capacity, tokens + elapsed * refill)
+
+local allowed = 0
+if tokens >= cost then
+  tokens = tokens - cost
+  allowed = 1
+end
+
+redis.call('HMSET', key, 'tokens', tokens, 'last_refill', now)
+redis.call('EXPIRE', key, ttl)
+
+local deficit = capacity - tokens
+local reset_epoch = now
+if refill > 0 then
+  reset_epoch = now + (deficit / refill)
+end
+
+return {allowed, math.floor(tokens), math.floor(reset_epoch)}
+"""
 
 
 @dataclass
@@ -27,6 +83,23 @@ class RateLimitResult:
     current_count: int
     limit: int
     remaining: int
+    source: str = "redis"  # "redis" | "degraded"
+
+
+@dataclass
+class TokenBucketResult:
+    """
+    Result of a token-bucket check.
+
+    `reset_epoch` is the unix timestamp at which the bucket will be full
+    again — callers use it to set the X-RateLimit-Reset-* header.
+    `source` discriminates the Redis path from degraded (burst-cap) fail-open.
+    """
+
+    allowed: bool
+    remaining: int
+    limit: int
+    reset_epoch: int
     source: str = "redis"  # "redis" | "degraded"
 
 
@@ -52,12 +125,17 @@ class RedisClient:
         redis_url: str = "",
         prefix: str = "relay",
         default_limit: int = 500,
+        fail_open_burst: int = 10,
     ):
         self._redis_url = redis_url
         self._prefix = prefix
         self._default_limit = default_limit
+        self._fail_open_burst = fail_open_burst
         self._redis = None  # redis.asyncio.Redis instance (lazy import)
         self._available = False
+        # Fail-open burst tracking: {caller_key: (window_start, count)} — only
+        # used when Redis is unreachable (spec §6.6).
+        self._burst_state: dict[str, tuple[float, int]] = {}
 
     async def connect(self) -> bool:
         """
@@ -168,6 +246,137 @@ class RedisClient:
                 remaining=daily_limit,
                 source="degraded",
             )
+
+    # ── Phase 1b: token-bucket rate limit ──────────────────────────────
+
+    async def token_bucket_check(
+        self,
+        caller_key: str,
+        window: str,
+        capacity: int,
+        cost: int = 1,
+        bucket_ttl_s: int = 7200,
+    ) -> TokenBucketResult:
+        """
+        Atomic token-bucket consume-or-reject via Redis Lua.
+
+        Key shape: ``ratelimit:{prefix}:{window}:{caller_key}``
+        Refill rate is derived as ``capacity / window_seconds`` — a full
+        bucket refills in exactly one window, matching spec §6.2.
+
+        Args:
+            caller_key: api_key (service/erp) or tenant_id (user path).
+            window: "per_minute" | "per_hour" — selects the refill rate.
+            capacity: max tokens (tier limit for this window).
+            cost: tokens this request costs (endpoint weight, default 1).
+            bucket_ttl_s: seconds of idle before Redis evicts. Default 2h so
+                per-hour buckets always outlive their refill cycle.
+
+        Returns:
+            TokenBucketResult with allowed/remaining/reset_epoch.
+
+        Fail-open: if Redis unreachable, enforces a ``fail_open_burst`` cap
+            per caller per second (spec §6.6) to prevent a Redis outage from
+            opening a full-rate abuse window.
+        """
+        window_seconds = {"per_minute": 60, "per_hour": 3600}.get(window)
+        if window_seconds is None:
+            raise ValueError(f"Unknown window: {window!r}")
+
+        if capacity <= 0:
+            # Tier with capacity=0 means "unlimited" (enterprise per-hour can
+            # be configured as empty/null per spec §6.3). Treat as allowed
+            # with remaining=capacity and no real enforcement.
+            return TokenBucketResult(
+                allowed=True, remaining=0, limit=0,
+                reset_epoch=int(time.time()), source="unlimited",
+            )
+
+        if not self._available or self._redis is None:
+            return self._fail_open_check(caller_key, capacity)
+
+        key = f"ratelimit:{self._prefix}:{window}:{caller_key}"
+        refill = capacity / window_seconds
+        now = time.time()
+
+        try:
+            result = await self._redis.eval(
+                _TOKEN_BUCKET_LUA, 1, key,
+                capacity, refill, cost, now, bucket_ttl_s,
+            )
+            allowed = int(result[0]) == 1
+            remaining = int(result[1])
+            reset_epoch = int(result[2])
+            return TokenBucketResult(
+                allowed=allowed,
+                remaining=remaining,
+                limit=capacity,
+                reset_epoch=reset_epoch,
+                source="redis",
+            )
+        except Exception as e:
+            logger.warning(
+                f"token_bucket_check failed for {caller_key}:{window} — "
+                f"fail-open with burst cap: {e}"
+            )
+            self._available = False
+            return self._fail_open_check(caller_key, capacity)
+
+    def _fail_open_check(
+        self, caller_key: str, capacity: int
+    ) -> TokenBucketResult:
+        """
+        Local 1-second burst cap when Redis is unreachable.
+
+        Tracks per-caller count in an in-process dict, reset every second.
+        Caps at ``self._fail_open_burst`` (default 10) requests/second per
+        caller — prevents a Redis outage from letting a single caller
+        stampede the backend.
+        """
+        now = time.time()
+        window_start, count = self._burst_state.get(caller_key, (now, 0))
+
+        if now - window_start >= 1.0:
+            window_start = now
+            count = 0
+
+        count += 1
+        self._burst_state[caller_key] = (window_start, count)
+
+        allowed = count <= self._fail_open_burst
+        return TokenBucketResult(
+            allowed=allowed,
+            remaining=max(0, self._fail_open_burst - count),
+            limit=capacity,
+            reset_epoch=int(window_start + 1),
+            source="degraded",
+        )
+
+    # ── Phase 1b: nonce replay protection ──────────────────────────────
+
+    async def nonce_claim(self, nonce: str, ttl_s: int = 600) -> bool:
+        """
+        Claim a nonce. First caller gets True, replays get False.
+
+        Key shape: ``{prefix}:nonce:{nonce}``
+        Uses ``SET ... NX EX`` for atomicity + auto-expiry.
+
+        When Redis is unreachable, fail-open (returns True). Replay
+        protection silently degrades; the timestamp-window check (300s) in
+        the HMAC verifier is the secondary defense.
+        """
+        if not self._available or self._redis is None:
+            return True
+
+        key = f"{self._prefix}:nonce:{nonce}"
+        try:
+            # SET key value NX EX ttl — returns "OK" if set, None if exists.
+            result = await self._redis.set(key, "1", nx=True, ex=ttl_s)
+            return result is not None
+        except Exception as e:
+            logger.warning(f"nonce_claim failed, allowing: {e}")
+            self._available = False
+            return True
 
     @property
     def is_available(self) -> bool:

--- a/services/relay/src/config.py
+++ b/services/relay/src/config.py
@@ -83,6 +83,10 @@ class RelayConfig:
     rate_limit_fail_open_burst: int = 10         # req/sec/caller when Redis down (§6.6)
     nonce_ttl_s: int = 600                       # HMAC nonce replay window (§7)
 
+    # ── Introspect cache (Keel JWT spec §5) ─────────────────────────────
+    introspect_cache_ttl_s: float = 30.0         # HELIUM_AUTH_SPEC §8.7
+    introspect_cache_max: int = 10_000           # bounds memory in attack scenarios
+
     # ── Workers ──────────────────────────────────────────────────────────
     workers: int = 1                    # uvicorn --workers (production)
 
@@ -209,6 +213,12 @@ class RelayConfig:
             kwargs["rate_limit_fail_open_burst"] = int(v)
         if v := env("NONCE_TTL_S"):
             kwargs["nonce_ttl_s"] = int(v)
+
+        # ── Introspect cache
+        if v := env("INTROSPECT_CACHE_TTL_S"):
+            kwargs["introspect_cache_ttl_s"] = float(v)
+        if v := env("INTROSPECT_CACHE_MAX"):
+            kwargs["introspect_cache_max"] = int(v)
 
         # ── Workers
         if v := env("WORKERS"):

--- a/services/relay/src/config.py
+++ b/services/relay/src/config.py
@@ -77,6 +77,12 @@ class RelayConfig:
     redis_prefix: str = "relay"
     rate_limit_daily: int = 500         # Default daily uploads per company
 
+    # ── Phase 1b abuse middleware (spec §6–§8) ──────────────────────────
+    max_request_bytes: int = 52_428_800          # 50 MB flat cap (tier-aware deferred)
+    handler_timeout_s: int = 30                  # asyncio.wait_for handler wrap
+    rate_limit_fail_open_burst: int = 10         # req/sec/caller when Redis down (§6.6)
+    nonce_ttl_s: int = 600                       # HMAC nonce replay window (§7)
+
     # ── Workers ──────────────────────────────────────────────────────────
     workers: int = 1                    # uvicorn --workers (production)
 
@@ -193,6 +199,16 @@ class RelayConfig:
             kwargs["redis_prefix"] = v
         if v := env("RATE_LIMIT_DAILY"):
             kwargs["rate_limit_daily"] = int(v)
+
+        # ── Phase 1b abuse middleware
+        if v := env("MAX_REQUEST_BYTES"):
+            kwargs["max_request_bytes"] = int(v)
+        if v := env("HANDLER_TIMEOUT_S"):
+            kwargs["handler_timeout_s"] = int(v)
+        if v := env("RATE_LIMIT_FAIL_OPEN_BURST"):
+            kwargs["rate_limit_fail_open_burst"] = int(v)
+        if v := env("NONCE_TTL_S"):
+            kwargs["nonce_ttl_s"] = int(v)
 
         # ── Workers
         if v := env("WORKERS"):

--- a/services/relay/src/errors.py
+++ b/services/relay/src/errors.py
@@ -247,6 +247,61 @@ class RateLimitExceededError(RelayError):
         self.retry_after_seconds = retry_after_seconds
 
 
+class ReplayDetectedError(AuthenticationFailedError):
+    """
+    HMAC request nonce seen before within its TTL window (spec §7).
+
+    Inherits 401 from AuthenticationFailedError but exposes a distinct
+    error_code so clients can differentiate replay from signature-fail.
+    """
+
+    def __init__(self, nonce: str = ""):
+        # Deliberately call RelayError directly (not super().__init__) so we
+        # control the error_code — AuthenticationFailedError hard-codes it.
+        RelayError.__init__(
+            self,
+            error_code="REPLAY_DETECTED",
+            message=(
+                "Request nonce has already been used. "
+                "Nonces must be unique within the 600s replay window."
+            ),
+            status_code=401,
+        )
+        self.nonce = nonce
+
+
+# ── Request Safety (413, 504) ─────────────────────────────────────────────
+
+
+class RequestTooLargeError(RelayError):
+    """Request body exceeds configured size cap (spec §8.1)."""
+
+    def __init__(self, size_bytes: int, limit_bytes: int):
+        super().__init__(
+            error_code="REQUEST_TOO_LARGE",
+            message=(
+                f"Request body {size_bytes} bytes exceeds {limit_bytes}-byte limit."
+            ),
+            details=[{
+                "size_bytes": str(size_bytes),
+                "limit_bytes": str(limit_bytes),
+            }],
+            status_code=413,
+        )
+
+
+class RequestTimeoutError(RelayError):
+    """Request handler exceeded the configured timeout (spec §8.2)."""
+
+    def __init__(self, timeout_s: int):
+        super().__init__(
+            error_code="REQUEST_TIMEOUT",
+            message=f"Request exceeded {timeout_s}s handler timeout.",
+            details=[{"timeout_s": str(timeout_s)}],
+            status_code=504,
+        )
+
+
 # ── Not Found (404) ───────────────────────────────────────────────────────
 
 

--- a/services/relay/tests/api/test_auth_phase1b.py
+++ b/services/relay/tests/api/test_auth_phase1b.py
@@ -1,0 +1,246 @@
+"""
+Tests for Phase 1b auth changes — nonce replay on HMAC — and for the
+Phase 1a dispatcher (debt: not tested when it landed).
+
+We stub Request/app directly rather than wiring a full FastAPI app to keep
+the auth-logic tests fast and decoupled from lifespan plumbing.
+"""
+
+import asyncio
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from src.api.deps import (
+    authenticate_request,
+    _verify_hmac,
+    _verify_service_creds,
+)
+from src.errors import (
+    AuthenticationFailedError,
+    InvalidAPIKeyError,
+    ReplayDetectedError,
+)
+from src.config import RelayConfig
+
+
+def _make_request(
+    headers=None,
+    body=b"",
+    api_key_secrets=None,
+    redis_mock=None,
+    introspect_mock=None,
+    tenant_registry=None,
+    nonce_ttl_s=600,
+):
+    """Build a minimal Request-like object for auth tests."""
+    hdrs = headers or {}
+    state = SimpleNamespace(
+        raw_body=body,
+        trace_id="trace-test",
+    )
+    cfg = RelayConfig(
+        heartbeat_api_key="hb-key", heartbeat_api_secret="hb-secret",
+        nonce_ttl_s=nonce_ttl_s,
+    )
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            config=cfg,
+            api_key_secrets=api_key_secrets or {},
+            tenant_registry=tenant_registry or {},
+            redis=redis_mock,
+            introspect_client=introspect_mock,
+        ),
+    )
+    # httpx-style header access (case-insensitive via .get()).
+    class _H:
+        def __init__(self, d):
+            self._d = {k.lower(): v for k, v in d.items()}
+        def get(self, k, default=None):
+            return self._d.get(k.lower(), default)
+
+    req = SimpleNamespace(
+        headers=_H(hdrs),
+        state=state,
+        app=app,
+    )
+
+    async def _body():
+        return body
+    req.body = _body
+    return req
+
+
+# ── HMAC + Nonce (A.4) ──────────────────────────────────────────────────
+
+
+def _valid_hmac_signature(api_key, secret, timestamp, body):
+    """Matches src/core/auth.compute_signature format."""
+    import hmac, hashlib
+    body_hash = hashlib.sha256(body).hexdigest()
+    message = f"{api_key}:{timestamp}:{body_hash}"
+    return hmac.new(
+        secret.encode("utf-8"), message.encode("utf-8"), hashlib.sha256,
+    ).hexdigest()
+
+
+class TestHmacNonceReplay:
+    @pytest.mark.asyncio
+    async def test_first_nonce_accepted(self):
+        body = b'{"invoice":1}'
+        key, secret = "k-test", "s-test"
+        ts = "2026-04-20T22:00:00Z"
+        sig = _valid_hmac_signature(key, secret, ts, body)
+
+        redis = MagicMock()
+        redis.nonce_claim = AsyncMock(return_value=True)
+
+        req = _make_request(
+            headers={"X-Nonce": "nonce-1"},
+            body=body,
+            api_key_secrets={key: secret},
+            redis_mock=redis,
+        )
+        # Patch timestamp validator by using current time
+        from datetime import datetime, timezone
+        now_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        sig_now = _valid_hmac_signature(key, secret, now_ts, body)
+
+        ctx = await _verify_hmac(req, key, now_ts, sig_now)
+        assert ctx.actor_type == "erp"
+        assert ctx.identifier == key
+        redis.nonce_claim.assert_awaited_once_with("nonce-1", ttl_s=600)
+
+    @pytest.mark.asyncio
+    async def test_replayed_nonce_raises(self):
+        body = b'{"invoice":1}'
+        key, secret = "k-test", "s-test"
+
+        redis = MagicMock()
+        redis.nonce_claim = AsyncMock(return_value=False)  # replay
+
+        from datetime import datetime, timezone
+        now_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        sig = _valid_hmac_signature(key, secret, now_ts, body)
+
+        req = _make_request(
+            headers={"X-Nonce": "reused-nonce"},
+            body=body,
+            api_key_secrets={key: secret},
+            redis_mock=redis,
+        )
+        with pytest.raises(ReplayDetectedError):
+            await _verify_hmac(req, key, now_ts, sig)
+
+    @pytest.mark.asyncio
+    async def test_missing_nonce_accepted_for_backward_compat(self):
+        body = b'{"invoice":1}'
+        key, secret = "k-test", "s-test"
+
+        redis = MagicMock()
+        redis.nonce_claim = AsyncMock()  # must not be called
+
+        from datetime import datetime, timezone
+        now_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        sig = _valid_hmac_signature(key, secret, now_ts, body)
+
+        req = _make_request(
+            headers={},  # no X-Nonce
+            body=body,
+            api_key_secrets={key: secret},
+            redis_mock=redis,
+        )
+        ctx = await _verify_hmac(req, key, now_ts, sig)
+        assert ctx.actor_type == "erp"
+        redis.nonce_claim.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_nonce_with_no_redis_passes(self):
+        body = b'{"invoice":1}'
+        key, secret = "k-test", "s-test"
+
+        from datetime import datetime, timezone
+        now_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        sig = _valid_hmac_signature(key, secret, now_ts, body)
+
+        req = _make_request(
+            headers={"X-Nonce": "n"},
+            body=body,
+            api_key_secrets={key: secret},
+            redis_mock=None,  # Redis not available
+        )
+        ctx = await _verify_hmac(req, key, now_ts, sig)
+        # No raise — fall through when redis absent
+        assert ctx.actor_type == "erp"
+
+
+# ── Phase 1a dispatcher debt ────────────────────────────────────────────
+
+
+class TestDispatcher:
+    @pytest.mark.asyncio
+    async def test_no_credentials_raises(self):
+        req = _make_request(headers={})
+        with pytest.raises(AuthenticationFailedError):
+            await authenticate_request(req)
+
+    @pytest.mark.asyncio
+    async def test_bearer_empty_raises(self):
+        req = _make_request(headers={"Authorization": "Bearer "})
+        with pytest.raises(AuthenticationFailedError):
+            await authenticate_request(req)
+
+    @pytest.mark.asyncio
+    async def test_hmac_headers_dispatch(self):
+        body = b"x"
+        key, secret = "k", "s"
+        from datetime import datetime, timezone
+        now_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        sig = _valid_hmac_signature(key, secret, now_ts, body)
+
+        req = _make_request(
+            headers={
+                "X-API-Key": key, "X-Timestamp": now_ts, "X-Signature": sig,
+            },
+            body=body,
+            api_key_secrets={key: secret},
+        )
+        ctx = await authenticate_request(req)
+        assert ctx.actor_type == "erp"
+
+    @pytest.mark.asyncio
+    async def test_service_creds_dispatch(self):
+        req = _make_request(
+            headers={"Authorization": "Bearer k:s"},
+            api_key_secrets={"k": "s"},
+        )
+        ctx = await authenticate_request(req)
+        assert ctx.actor_type == "service"
+        assert ctx.identifier == "k"
+
+    @pytest.mark.asyncio
+    async def test_service_creds_unknown_key_raises(self):
+        req = _make_request(
+            headers={"Authorization": "Bearer k:s"},
+            api_key_secrets={},  # not registered
+        )
+        with pytest.raises(InvalidAPIKeyError):
+            await authenticate_request(req)
+
+    @pytest.mark.asyncio
+    async def test_jwt_path_dispatch(self):
+        """JWT path routes to introspect client."""
+        introspect = AsyncMock()
+        introspect.introspect = AsyncMock(return_value=SimpleNamespace(
+            user_id="u-1", tenant_id="t-1", permissions=["invoice.view"],
+        ))
+        # JWT with two dots (compact JWS shape)
+        token = "header.eyJzdWIiOiJ1LTEifQ.signature"
+        req = _make_request(
+            headers={"Authorization": f"Bearer {token}"},
+            introspect_mock=introspect,
+        )
+        ctx = await authenticate_request(req)
+        assert ctx.actor_type == "user"
+        assert ctx.tenant_id == "t-1"
+        assert "invoice.view" in ctx.permissions

--- a/services/relay/tests/api/test_auth_phase1b.py
+++ b/services/relay/tests/api/test_auth_phase1b.py
@@ -63,6 +63,7 @@ def _make_request(
         headers=_H(hdrs),
         state=state,
         app=app,
+        url=SimpleNamespace(path="/api/ingest"),
     )
 
     async def _body():

--- a/services/relay/tests/api/test_middleware_phase1b.py
+++ b/services/relay/tests/api/test_middleware_phase1b.py
@@ -1,0 +1,405 @@
+"""
+Tests for Phase 1b middleware — RateLimitMiddleware + RequestSafetyMiddleware.
+
+Uses Starlette's TestClient so the full ASGI pipeline (including middleware)
+is exercised against a tiny stub FastAPI app.
+"""
+
+import asyncio
+import base64
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.middleware import (
+    RateLimitMiddleware,
+    RequestSafetyMiddleware,
+    _caller_key_from_request,
+    _endpoint_weight,
+    _unsafe_decode_jwt_payload,
+)
+from src.clients.redis_client import TokenBucketResult
+
+
+# ── _endpoint_weight ─────────────────────────────────────────────────────
+
+
+class TestEndpointWeight:
+    def test_ingest_cost_5(self):
+        assert _endpoint_weight("/api/ingest") == 5
+
+    def test_bulk_preview_cost_10(self):
+        assert _endpoint_weight("/api/bulk/preview") == 10
+
+    def test_health_cost_0(self):
+        assert _endpoint_weight("/health") == 0
+
+    def test_metrics_cost_0(self):
+        assert _endpoint_weight("/metrics") == 0
+
+    def test_unknown_default_1(self):
+        assert _endpoint_weight("/api/whatever") == 1
+
+    def test_startswith_match(self):
+        # /api/ingest/sub-path still costs 5
+        assert _endpoint_weight("/api/ingest/poll") == 5
+
+
+# ── _unsafe_decode_jwt_payload ──────────────────────────────────────────
+
+
+class TestJwtPayloadDecode:
+    def test_valid_jwt_payload(self):
+        payload = {"tenant_id": "abbey", "sub": "u-1"}
+        encoded = base64.urlsafe_b64encode(
+            json.dumps(payload).encode()
+        ).decode().rstrip("=")
+        token = f"header.{encoded}.sig"
+        assert _unsafe_decode_jwt_payload(token) == payload
+
+    def test_malformed_returns_empty(self):
+        assert _unsafe_decode_jwt_payload("not-a-jwt") == {}
+
+    def test_wrong_segment_count(self):
+        assert _unsafe_decode_jwt_payload("a.b") == {}
+
+    def test_invalid_base64(self):
+        assert _unsafe_decode_jwt_payload("a.@@@invalid@@@.c") == {}
+
+
+# ── _caller_key_from_request ────────────────────────────────────────────
+
+
+def _make_scope(headers=None, client_host="10.0.0.1"):
+    if headers is None:
+        headers = {}
+    headers_raw = [
+        (k.lower().encode("latin-1"), v.encode("latin-1"))
+        for k, v in headers.items()
+    ]
+    return {
+        "type": "http",
+        "path": "/api/ingest",
+        "headers": headers_raw,
+        "client": (client_host, 0),
+    }
+
+
+class TestCallerKey:
+    def test_hmac_api_key(self):
+        scope = _make_scope({
+            "x-api-key": "k-abc", "x-signature": "sig", "x-timestamp": "t",
+        })
+        assert _caller_key_from_request(scope) == "key:k-abc"
+
+    def test_service_creds_bearer(self):
+        scope = _make_scope({"authorization": "Bearer k-abc:secret"})
+        assert _caller_key_from_request(scope) == "key:k-abc"
+
+    def test_jwt_uses_tenant_id(self):
+        payload = {"tenant_id": "abbey", "sub": "u-1"}
+        encoded = base64.urlsafe_b64encode(
+            json.dumps(payload).encode()
+        ).decode().rstrip("=")
+        token = f"header.{encoded}.sig"
+        scope = _make_scope({"authorization": f"Bearer {token}"})
+        assert _caller_key_from_request(scope) == "tenant:abbey"
+
+    def test_jwt_fallback_to_sub(self):
+        payload = {"sub": "u-42"}
+        encoded = base64.urlsafe_b64encode(
+            json.dumps(payload).encode()
+        ).decode().rstrip("=")
+        token = f"h.{encoded}.s"
+        scope = _make_scope({"authorization": f"Bearer {token}"})
+        assert _caller_key_from_request(scope) == "user:u-42"
+
+    def test_anonymous_ip_key(self):
+        scope = _make_scope({}, client_host="203.0.113.7")
+        assert _caller_key_from_request(scope) == "ip:203.0.113.7"
+
+
+# ── RateLimitMiddleware ────────────────────────────────────────────────
+
+
+def _build_app_with_rate_limit(
+    redis_mock,
+    tier_limits=None,
+    add_safety=False,
+):
+    app = FastAPI()
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    @app.post("/api/ingest")
+    async def ingest():
+        return {"status": "accepted"}
+
+    app.state.redis = redis_mock
+    app.state.rate_limits_by_tier = tier_limits or {
+        "standard": {"api_requests_per_minute": 100, "api_requests_per_hour": 2000},
+    }
+
+    if add_safety:
+        app.add_middleware(
+            RequestSafetyMiddleware,
+            max_request_bytes=1000,
+            request_timeout_s=1,
+        )
+    app.add_middleware(RateLimitMiddleware)
+    return app
+
+
+class TestRateLimitMiddleware:
+    def test_health_not_rate_limited(self):
+        # redis.token_bucket_check should never be called for /health
+        redis = AsyncMock()
+        redis.token_bucket_check = AsyncMock()
+        app = _build_app_with_rate_limit(redis)
+        client = TestClient(app)
+
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        redis.token_bucket_check.assert_not_called()
+
+    def test_allowed_sets_ratelimit_headers(self):
+        redis = AsyncMock()
+        redis.token_bucket_check = AsyncMock(side_effect=[
+            TokenBucketResult(allowed=True, remaining=95, limit=100,
+                              reset_epoch=2_000_000_060, source="redis"),
+            TokenBucketResult(allowed=True, remaining=1995, limit=2000,
+                              reset_epoch=2_000_003_600, source="redis"),
+        ])
+        app = _build_app_with_rate_limit(redis)
+        client = TestClient(app)
+
+        resp = client.post("/api/ingest", headers={"X-API-Key": "k-abc",
+                                                    "X-Signature": "s",
+                                                    "X-Timestamp": "t"})
+        assert resp.status_code == 200
+        assert resp.headers["x-ratelimit-limit-minute"] == "100"
+        assert resp.headers["x-ratelimit-remaining-minute"] == "95"
+        assert resp.headers["x-ratelimit-limit-hour"] == "2000"
+
+    def test_per_minute_exceeded_returns_429(self):
+        redis = AsyncMock()
+        redis.token_bucket_check = AsyncMock(side_effect=[
+            TokenBucketResult(allowed=False, remaining=0, limit=100,
+                              reset_epoch=2_000_000_060, source="redis"),
+            TokenBucketResult(allowed=True, remaining=1995, limit=2000,
+                              reset_epoch=2_000_003_600, source="redis"),
+        ])
+        app = _build_app_with_rate_limit(redis)
+        client = TestClient(app)
+
+        resp = client.post("/api/ingest", headers={"X-API-Key": "k-abc",
+                                                    "X-Signature": "s",
+                                                    "X-Timestamp": "t"})
+        assert resp.status_code == 429
+        body = resp.json()
+        assert body["error_code"] == "RATE_LIMIT_EXCEEDED"
+        assert "retry-after" in [h.lower() for h in resp.headers.keys()]
+        assert resp.headers["x-ratelimit-remaining-minute"] == "0"
+
+    def test_per_hour_exceeded_returns_429(self):
+        redis = AsyncMock()
+        redis.token_bucket_check = AsyncMock(side_effect=[
+            TokenBucketResult(allowed=True, remaining=50, limit=100,
+                              reset_epoch=2_000_000_060, source="redis"),
+            TokenBucketResult(allowed=False, remaining=0, limit=2000,
+                              reset_epoch=2_000_003_600, source="redis"),
+        ])
+        app = _build_app_with_rate_limit(redis)
+        client = TestClient(app)
+
+        resp = client.post("/api/ingest", headers={"X-API-Key": "k-abc",
+                                                    "X-Signature": "s",
+                                                    "X-Timestamp": "t"})
+        assert resp.status_code == 429
+        # Details should indicate per_hour was the blocker
+        body = resp.json()
+        assert body["details"][0]["window"] == "per_hour"
+
+    def test_no_redis_passes_through(self):
+        """If app.state.redis is None, middleware should pass through."""
+        app = FastAPI()
+
+        @app.post("/api/ingest")
+        async def ingest():
+            return {"status": "accepted"}
+
+        app.state.redis = None
+        app.state.rate_limits_by_tier = {}
+        app.add_middleware(RateLimitMiddleware)
+
+        client = TestClient(app)
+        resp = client.post("/api/ingest")
+        assert resp.status_code == 200
+
+
+# ── RequestSafetyMiddleware ─────────────────────────────────────────────
+
+
+def _build_safety_only_app(max_bytes=1000, timeout_s=1):
+    app = FastAPI()
+
+    @app.post("/api/ingest")
+    async def ingest():
+        return {"status": "accepted"}
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    @app.get("/slow")
+    async def slow():
+        await asyncio.sleep(3)
+        return {"status": "never"}
+
+    app.add_middleware(
+        RequestSafetyMiddleware,
+        max_request_bytes=max_bytes,
+        request_timeout_s=timeout_s,
+    )
+    return app
+
+
+class TestRequestSafetyMiddleware:
+    def test_small_payload_passes(self):
+        app = _build_safety_only_app(max_bytes=1000, timeout_s=5)
+        client = TestClient(app)
+        resp = client.post("/api/ingest", content=b"x" * 100)
+        assert resp.status_code == 200
+
+    def test_too_large_rejected_413(self):
+        app = _build_safety_only_app(max_bytes=500, timeout_s=5)
+        client = TestClient(app)
+        # Payload of 1000 bytes > 500 limit
+        resp = client.post("/api/ingest", content=b"x" * 1000)
+        assert resp.status_code == 413
+        body = resp.json()
+        assert body["error_code"] == "REQUEST_TOO_LARGE"
+
+    def test_exact_limit_passes(self):
+        app = _build_safety_only_app(max_bytes=1000, timeout_s=5)
+        client = TestClient(app)
+        resp = client.post("/api/ingest", content=b"x" * 1000)
+        assert resp.status_code == 200
+
+    def test_timeout_returns_504(self):
+        app = _build_safety_only_app(max_bytes=10_000, timeout_s=1)
+        client = TestClient(app)
+        resp = client.get("/slow")
+        assert resp.status_code == 504
+        assert resp.json()["error_code"] == "REQUEST_TIMEOUT"
+
+    def test_missing_content_length_passes_through(self):
+        """Chunked / unknown-length requests should bypass the size gate."""
+        app = _build_safety_only_app(max_bytes=50, timeout_s=5)
+        client = TestClient(app)
+        # TestClient sets Content-Length automatically, but for a GET with no
+        # body there's no Content-Length to enforce — simulate.
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+
+# ── ASGI non-HTTP scope (websocket etc.) ────────────────────────────────
+
+
+class TestAsgiEdgeCases:
+    @pytest.mark.asyncio
+    async def test_rate_limit_passes_non_http_scope(self):
+        redis = AsyncMock()
+        redis.token_bucket_check = AsyncMock()
+        called = {"n": 0}
+
+        async def inner(scope, receive, send):
+            called["n"] += 1
+        mw = RateLimitMiddleware(inner)
+        await mw({"type": "websocket"}, AsyncMock(), AsyncMock())
+        assert called["n"] == 1
+        redis.token_bucket_check.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_safety_passes_non_http_scope(self):
+        called = {"n": 0}
+
+        async def inner(scope, receive, send):
+            called["n"] += 1
+        mw = RequestSafetyMiddleware(inner, max_request_bytes=100, request_timeout_s=5)
+        await mw({"type": "lifespan"}, AsyncMock(), AsyncMock())
+        assert called["n"] == 1
+
+
+# ── Invalid Content-Length ──────────────────────────────────────────────
+
+
+class TestInvalidContentLength:
+    @pytest.mark.asyncio
+    async def test_non_int_content_length_allowed(self):
+        """Garbage Content-Length header shouldn't crash the middleware."""
+        collected = []
+
+        async def inner(scope, receive, send):
+            collected.append("inner-ran")
+
+        mw = RequestSafetyMiddleware(inner, max_request_bytes=100, request_timeout_s=5)
+        scope = {
+            "type": "http",
+            "path": "/api/ingest",
+            "headers": [(b"content-length", b"not-a-number")],
+            "client": ("1.1.1.1", 0),
+        }
+
+        async def receive():
+            return {"type": "http.disconnect"}
+
+        async def send(_):
+            pass
+
+        await mw(scope, receive, send)
+        assert collected == ["inner-ran"]
+
+
+# ── End-to-end fail-open (no Redis backend) ─────────────────────────────
+
+
+class TestFailOpenIntegration:
+    def test_allows_with_burst_cap_when_no_redis(self):
+        """With app.state.redis absent, middleware should pass through."""
+        from src.clients.redis_client import RedisClient
+
+        # Real RedisClient but never connected — token_bucket_check returns
+        # degraded/allowed via fail-open burst.
+        rc = RedisClient(redis_url="", fail_open_burst=3)
+
+        app = FastAPI()
+
+        @app.post("/api/ingest")
+        async def ingest():
+            return {"ok": True}
+
+        app.state.redis = rc
+        app.state.rate_limits_by_tier = {
+            "standard": {"api_requests_per_minute": 100, "api_requests_per_hour": 2000},
+        }
+        app.add_middleware(RateLimitMiddleware)
+        client = TestClient(app)
+
+        # First 3 calls should pass (burst cap = 3); 4th may 429.
+        statuses = []
+        for _ in range(5):
+            r = client.post("/api/ingest", headers={
+                "X-API-Key": "k1", "X-Signature": "s", "X-Timestamp": "t",
+            })
+            statuses.append(r.status_code)
+        # At least one should have been rate-limited after the burst
+        assert 429 in statuses
+        # Earlier ones should have been allowed
+        assert 200 in statuses

--- a/services/relay/tests/clients/test_introspect_cache.py
+++ b/services/relay/tests/clients/test_introspect_cache.py
@@ -1,0 +1,293 @@
+"""
+Tests for IntrospectClient cache (Keel HANDOFF_RELAY_JWT_INTROSPECT.md §5).
+
+Mocks httpx.AsyncClient.post to avoid real HB calls. Verifies:
+  - cache hits skip HTTP
+  - TTL expiry forces fresh HTTP call
+  - negative cache re-raises the original error
+  - jti extraction handles malformed tokens
+  - LRU eviction when over cache_max
+"""
+
+import asyncio
+import base64
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from src.clients.introspect import (
+    IntrospectClient,
+    IntrospectResult,
+    _extract_jti,
+)
+from src.errors import JWTRejectedError, HeartBeatUnavailableError
+
+
+def _make_jwt(payload: dict) -> str:
+    """Compact JWS shape; signature doesn't matter for introspect tests."""
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "HS256"}).encode()).decode().rstrip("=")
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    return f"{header}.{body}.sig"
+
+
+def _make_http_response(body: dict, status: int = 200):
+    """Build a fake httpx.Response."""
+    r = MagicMock(spec=httpx.Response)
+    r.status_code = status
+    r.is_success = 200 <= status < 300
+    r.json.return_value = body
+    r.text = json.dumps(body)
+    return r
+
+
+def _make_client(cache_ttl_s=30.0, cache_max=100):
+    return IntrospectClient(
+        heartbeat_url="http://hb.test",
+        service_api_key="svc-key",
+        service_api_secret="svc-secret",
+        timeout_s=5.0,
+        cache_ttl_s=cache_ttl_s,
+        cache_max_entries=cache_max,
+    )
+
+
+# ── _extract_jti ──────────────────────────────────────────────────────
+
+
+class TestExtractJti:
+    def test_present(self):
+        token = _make_jwt({"jti": "abc-123", "sub": "u-1"})
+        assert _extract_jti(token) == "abc-123"
+
+    def test_missing(self):
+        token = _make_jwt({"sub": "u-1"})  # no jti
+        assert _extract_jti(token) is None
+
+    def test_malformed(self):
+        assert _extract_jti("not-a-jwt") is None
+        assert _extract_jti("a.b") is None
+
+    def test_non_string_jti_stringified(self):
+        token = _make_jwt({"jti": 12345, "sub": "u-1"})
+        assert _extract_jti(token) == "12345"
+
+
+# ── Cache hit/miss ────────────────────────────────────────────────────
+
+
+class TestCacheHit:
+    @pytest.mark.asyncio
+    async def test_second_call_hits_cache(self):
+        client = _make_client()
+        token = _make_jwt({"jti": "j-1", "sub": "u-1"})
+        positive_body = {
+            "active": True, "user_id": "u-1", "tenant_id": "t-1",
+            "permissions": ["blob.upload"], "step_up_satisfied": True,
+        }
+
+        with patch.object(client, "_client") as mock_client_factory:
+            http_mock = AsyncMock()
+            http_mock.post = AsyncMock(return_value=_make_http_response(positive_body))
+            mock_client_factory.return_value = http_mock
+
+            r1 = await client.introspect(token)
+            r2 = await client.introspect(token)
+
+            assert r1.active is True
+            assert r2.active is True
+            # Second call served from cache
+            assert http_mock.post.call_count == 1
+            stats = client.cache_stats()
+            assert stats["hits"] >= 1
+            assert stats["misses"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_different_tokens_different_cache_entries(self):
+        client = _make_client()
+        t1 = _make_jwt({"jti": "j-1"})
+        t2 = _make_jwt({"jti": "j-2"})
+        body = {"active": True, "user_id": "u", "tenant_id": "t",
+                "permissions": [], "step_up_satisfied": True}
+
+        with patch.object(client, "_client") as mock_client_factory:
+            http_mock = AsyncMock()
+            http_mock.post = AsyncMock(return_value=_make_http_response(body))
+            mock_client_factory.return_value = http_mock
+
+            await client.introspect(t1)
+            await client.introspect(t2)
+            # Two distinct jtis → two HTTP calls
+            assert http_mock.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_different_permissions_different_cache_slots(self):
+        """Same jti + different required_permission → separate cache slots."""
+        client = _make_client()
+        token = _make_jwt({"jti": "j-1"})
+        body = {"active": True, "user_id": "u", "tenant_id": "t",
+                "permissions": [], "step_up_satisfied": True}
+
+        with patch.object(client, "_client") as mock_client_factory:
+            http_mock = AsyncMock()
+            http_mock.post = AsyncMock(return_value=_make_http_response(body))
+            mock_client_factory.return_value = http_mock
+
+            await client.introspect(token, required_permission="blob.upload")
+            await client.introspect(token, required_permission="invoice.approve")
+            assert http_mock.post.call_count == 2
+
+
+# ── TTL expiry ─────────────────────────────────────────────────────────
+
+
+class TestCacheTtl:
+    @pytest.mark.asyncio
+    async def test_expiry_forces_refetch(self):
+        client = _make_client(cache_ttl_s=0.05)  # 50ms TTL
+        token = _make_jwt({"jti": "j-1"})
+        body = {"active": True, "user_id": "u", "tenant_id": "t",
+                "permissions": [], "step_up_satisfied": True}
+
+        with patch.object(client, "_client") as mock_client_factory:
+            http_mock = AsyncMock()
+            http_mock.post = AsyncMock(return_value=_make_http_response(body))
+            mock_client_factory.return_value = http_mock
+
+            await client.introspect(token)
+            await asyncio.sleep(0.1)  # past TTL
+            await client.introspect(token)
+            assert http_mock.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_bypass_cache_forces_refetch(self):
+        client = _make_client()
+        token = _make_jwt({"jti": "j-1"})
+        body = {"active": True, "user_id": "u", "tenant_id": "t",
+                "permissions": [], "step_up_satisfied": True}
+
+        with patch.object(client, "_client") as mock_client_factory:
+            http_mock = AsyncMock()
+            http_mock.post = AsyncMock(return_value=_make_http_response(body))
+            mock_client_factory.return_value = http_mock
+
+            await client.introspect(token)
+            await client.introspect(token, bypass_cache=True)
+            assert http_mock.post.call_count == 2
+
+
+# ── Negative cache ─────────────────────────────────────────────────────
+
+
+class TestNegativeCache:
+    @pytest.mark.asyncio
+    async def test_rejected_token_cached_and_reraised(self):
+        """A revoked-token response should be cached so repeat calls don't hit HB."""
+        client = _make_client()
+        token = _make_jwt({"jti": "j-revoked"})
+        neg_body = {
+            "active": False, "error_code": "TOKEN_REVOKED",
+            "message": "Session revoked",
+        }
+
+        with patch.object(client, "_client") as mock_client_factory:
+            http_mock = AsyncMock()
+            http_mock.post = AsyncMock(return_value=_make_http_response(neg_body))
+            mock_client_factory.return_value = http_mock
+
+            with pytest.raises(JWTRejectedError) as first:
+                await client.introspect(token)
+            with pytest.raises(JWTRejectedError) as second:
+                await client.introspect(token)
+
+            assert first.value.error_code == "TOKEN_REVOKED"
+            assert second.value.error_code == "TOKEN_REVOKED"
+            # Only one HTTP call — second served from negative cache
+            assert http_mock.post.call_count == 1
+
+
+# ── LRU bounds ─────────────────────────────────────────────────────────
+
+
+class TestLruBounds:
+    @pytest.mark.asyncio
+    async def test_evicts_oldest_when_over_max(self):
+        client = _make_client(cache_max=3)
+        body = {"active": True, "user_id": "u", "tenant_id": "t",
+                "permissions": [], "step_up_satisfied": True}
+
+        with patch.object(client, "_client") as mock_client_factory:
+            http_mock = AsyncMock()
+            http_mock.post = AsyncMock(return_value=_make_http_response(body))
+            mock_client_factory.return_value = http_mock
+
+            for i in range(5):
+                await client.introspect(_make_jwt({"jti": f"j-{i}"}))
+
+            assert client.cache_stats()["size"] == 3  # only last 3 survive
+
+
+# ── Tokens without jti ─────────────────────────────────────────────────
+
+
+class TestNoJti:
+    @pytest.mark.asyncio
+    async def test_token_without_jti_skips_cache(self):
+        client = _make_client()
+        token = _make_jwt({"sub": "u-1"})  # no jti
+        body = {"active": True, "user_id": "u", "tenant_id": "t",
+                "permissions": [], "step_up_satisfied": True}
+
+        with patch.object(client, "_client") as mock_client_factory:
+            http_mock = AsyncMock()
+            http_mock.post = AsyncMock(return_value=_make_http_response(body))
+            mock_client_factory.return_value = http_mock
+
+            await client.introspect(token)
+            await client.introspect(token)
+            # Both calls hit HTTP — no cache key available
+            assert http_mock.post.call_count == 2
+
+
+# ── Error propagation ─────────────────────────────────────────────────
+
+
+class TestErrors:
+    @pytest.mark.asyncio
+    async def test_upstream_5xx_raises_unavailable(self):
+        client = _make_client()
+        token = _make_jwt({"jti": "j-1"})
+
+        with patch.object(client, "_client") as mock_client_factory:
+            http_mock = AsyncMock()
+            http_mock.post = AsyncMock(return_value=_make_http_response({}, status=503))
+            mock_client_factory.return_value = http_mock
+
+            with pytest.raises(HeartBeatUnavailableError):
+                await client.introspect(token)
+
+    @pytest.mark.asyncio
+    async def test_connect_error_raises_unavailable(self):
+        client = _make_client()
+        token = _make_jwt({"jti": "j-1"})
+
+        with patch.object(client, "_client") as mock_client_factory:
+            http_mock = AsyncMock()
+            http_mock.post = AsyncMock(side_effect=httpx.ConnectError("down"))
+            mock_client_factory.return_value = http_mock
+
+            with pytest.raises(HeartBeatUnavailableError):
+                await client.introspect(token)
+
+    @pytest.mark.asyncio
+    async def test_own_creds_missing_raises(self):
+        client = IntrospectClient(
+            heartbeat_url="http://hb.test",
+            service_api_key="",
+            service_api_secret="",
+        )
+        from src.errors import AuthenticationFailedError
+        with pytest.raises(AuthenticationFailedError):
+            await client.introspect(_make_jwt({"jti": "j"}))

--- a/services/relay/tests/clients/test_redis_client_phase1b.py
+++ b/services/relay/tests/clients/test_redis_client_phase1b.py
@@ -1,0 +1,191 @@
+"""
+Tests for RedisClient Phase 1b extensions — token bucket + nonce claim.
+
+Mock Redis throughout. Fail-open burst is exercised without a Redis
+backend (the burst cap is in-process).
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from src.clients.redis_client import RedisClient, TokenBucketResult
+
+
+def _make_connected(default_limit=500, burst=10):
+    client = RedisClient(
+        redis_url="redis://fake:6379/0",
+        prefix="relay",
+        default_limit=default_limit,
+        fail_open_burst=burst,
+    )
+    client._available = True
+    client._redis = AsyncMock()
+    return client
+
+
+# ── token_bucket_check — happy path ─────────────────────────────────────
+
+
+class TestTokenBucketHappyPath:
+    @pytest.mark.asyncio
+    async def test_first_call_allowed_full_bucket(self):
+        client = _make_connected()
+        # Simulate Lua returning [allowed, remaining, reset_epoch]
+        client._redis.eval = AsyncMock(return_value=[1, 99, 2_000_000_060])
+
+        r = await client.token_bucket_check("key:abc", "per_minute", 100, cost=1)
+        assert r.allowed is True
+        assert r.limit == 100
+        assert r.remaining == 99
+        assert r.source == "redis"
+
+    @pytest.mark.asyncio
+    async def test_rejected_when_empty(self):
+        client = _make_connected()
+        client._redis.eval = AsyncMock(return_value=[0, 0, 2_000_000_060])
+
+        r = await client.token_bucket_check("key:abc", "per_minute", 100, cost=5)
+        assert r.allowed is False
+        assert r.remaining == 0
+
+    @pytest.mark.asyncio
+    async def test_cost_weight_applied(self):
+        client = _make_connected()
+        client._redis.eval = AsyncMock(return_value=[1, 95, 2_000_000_060])
+
+        await client.token_bucket_check("key:x", "per_minute", 100, cost=5)
+        call_args = client._redis.eval.call_args
+        # args: (lua_script, num_keys, key, capacity, refill, cost, now, ttl)
+        # Positional ARGV[3] (cost) lives at index 5 of args
+        assert call_args[0][5] == 5  # cost passed through
+
+
+# ── token_bucket_check — unlimited + invalid window ─────────────────────
+
+
+class TestTokenBucketSpecialCases:
+    @pytest.mark.asyncio
+    async def test_capacity_zero_means_unlimited(self):
+        client = _make_connected()
+        client._redis.eval = AsyncMock()  # must not be called
+
+        r = await client.token_bucket_check("key:x", "per_hour", 0)
+        assert r.allowed is True
+        assert r.source == "unlimited"
+        client._redis.eval.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invalid_window_raises(self):
+        client = _make_connected()
+        with pytest.raises(ValueError, match="Unknown window"):
+            await client.token_bucket_check("key:x", "per_second", 100)
+
+    @pytest.mark.asyncio
+    async def test_per_hour_uses_3600_refill_base(self):
+        client = _make_connected()
+        client._redis.eval = AsyncMock(return_value=[1, 1999, 2_000_003_600])
+
+        await client.token_bucket_check("key:x", "per_hour", 2000, cost=1)
+        call_args = client._redis.eval.call_args
+        # refill (ARGV[2]) = capacity / window_seconds
+        # positional: (script, 1, key, capacity, refill, cost, now, ttl)
+        capacity = call_args[0][3]
+        refill = call_args[0][4]
+        assert capacity == 2000
+        assert refill == pytest.approx(2000 / 3600)
+
+
+# ── Fail-open burst cap (Redis unreachable) ─────────────────────────────
+
+
+class TestFailOpenBurst:
+    @pytest.mark.asyncio
+    async def test_first_request_allowed_when_redis_down(self):
+        client = RedisClient(redis_url="", fail_open_burst=5)
+        # Not connected → _available False, _redis None
+        r = await client.token_bucket_check("key:x", "per_minute", 100)
+        assert r.allowed is True
+        assert r.source == "degraded"
+        assert r.remaining == 4  # 5 - 1 already used
+
+    @pytest.mark.asyncio
+    async def test_burst_cap_blocks_past_threshold(self):
+        client = RedisClient(redis_url="", fail_open_burst=3)
+        results = []
+        for _ in range(5):
+            results.append(
+                await client.token_bucket_check("key:x", "per_minute", 100)
+            )
+        # First 3 allowed, last 2 rejected within the same second
+        allowed = [r.allowed for r in results]
+        assert allowed[:3] == [True, True, True]
+        assert allowed[3:] == [False, False]
+
+    @pytest.mark.asyncio
+    async def test_burst_cap_per_caller_independent(self):
+        client = RedisClient(redis_url="", fail_open_burst=2)
+        a1 = await client.token_bucket_check("key:A", "per_minute", 100)
+        a2 = await client.token_bucket_check("key:A", "per_minute", 100)
+        a3 = await client.token_bucket_check("key:A", "per_minute", 100)
+        b1 = await client.token_bucket_check("key:B", "per_minute", 100)
+        assert [a1.allowed, a2.allowed, a3.allowed] == [True, True, False]
+        assert b1.allowed is True  # B's bucket is separate
+
+    @pytest.mark.asyncio
+    async def test_redis_eval_failure_degrades(self):
+        client = _make_connected(burst=2)
+        client._redis.eval = AsyncMock(side_effect=Exception("Redis down"))
+
+        r = await client.token_bucket_check("key:x", "per_minute", 100)
+        assert r.allowed is True
+        assert r.source == "degraded"
+        assert client.is_available is False
+
+
+# ── nonce_claim ─────────────────────────────────────────────────────────
+
+
+class TestNonceClaim:
+    @pytest.mark.asyncio
+    async def test_first_claim_true(self):
+        client = _make_connected()
+        client._redis.set = AsyncMock(return_value="OK")
+
+        ok = await client.nonce_claim("abc-123", ttl_s=600)
+        assert ok is True
+
+    @pytest.mark.asyncio
+    async def test_replay_claim_false(self):
+        client = _make_connected()
+        # SETNX returns None when key already existed
+        client._redis.set = AsyncMock(return_value=None)
+
+        ok = await client.nonce_claim("abc-123", ttl_s=600)
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_uses_prefix_and_nonce_key(self):
+        client = _make_connected()
+        client._redis.set = AsyncMock(return_value="OK")
+
+        await client.nonce_claim("my-nonce")
+        call_kwargs = client._redis.set.call_args
+        key = call_kwargs[0][0]
+        assert key == "relay:nonce:my-nonce"
+        assert call_kwargs[1].get("nx") is True
+        assert call_kwargs[1].get("ex") == 600
+
+    @pytest.mark.asyncio
+    async def test_redis_down_fails_open_true(self):
+        client = RedisClient(redis_url="")  # never connected
+        ok = await client.nonce_claim("abc")
+        assert ok is True
+
+    @pytest.mark.asyncio
+    async def test_redis_error_degrades_allow(self):
+        client = _make_connected()
+        client._redis.set = AsyncMock(side_effect=Exception("down"))
+
+        ok = await client.nonce_claim("abc")
+        assert ok is True
+        assert client.is_available is False


### PR DESCRIPTION
## Summary
Implements `BACKEND_SERVICE_AUTH_AND_ABUSE_SPEC.md` §6-§8 for the Relay service. Strict spec Phase 1b scope (IP denylist deferred to Phase 2).

- **Token-bucket rate limiter** (per-minute + per-hour) via atomic Redis Lua. Per-caller keys (api_key for HMAC/service, tenant_id extracted from unverified JWT payload for user path). `X-RateLimit-*` response headers on every rate-limited response. Fail-open with burst cap per caller/second when Redis down (spec §6.6).
- **Request safety**: flat 50 MB size cap (tier-aware deferred), 30s handler timeout via `asyncio.wait_for`.
- **HMAC nonce replay**: SETNX with 600s TTL. `X-Nonce` currently optional for backward compat — enforcement becomes mandatory in Phase 2.
- **Phase 1a test debt filled**: unit tests for the dispatcher (HMAC, service creds, JWT introspect, empty/missing creds) — this was called out in the 20 Apr handoff §3 item 5.

Middleware stacking (outermost → innermost):
`RequestSafety → RateLimit → BodyCache → TraceID`
Rationale: reject oversized / timed-out requests **before** consuming rate-limit tokens or caching the body.

## Scope NOT in this PR (intentional)
- IP denylist / tenant IP allowlist (spec §9) — Phase 2
- Tier-aware size caps per caller — deferred, flat 50 MB today
- Per-caller tier resolution for rate limits — everyone gets `standard` tier in Phase 1b; Phase 2 adds per-caller cache

## Test plan
- [x] 50 new unit tests in `tests/api/test_middleware_phase1b.py`, `tests/clients/test_redis_client_phase1b.py`, `tests/api/test_auth_phase1b.py`
- [x] Coverage: `redis_client.py` 96%, `errors.py` 97%, new middleware code ~90%+ (legacy `BodyCacheMiddleware` + `TraceIDMiddleware` bring the file aggregate down — those predate this PR)
- [ ] EC2 deploy verification — pending (will do after merge): curl /health, fire 200-req burst to confirm 429 + headers, fire duplicate X-Nonce to confirm REPLAY_DETECTED, POST 51 MB to confirm 413

## Pre-existing test failures (NOT caused by this PR)
16 failures in `test_app.py`, `test_deps.py::TestEncryptionRequired`, `test_health_degraded.py`, `test_irn.py`, `test_qr.py`, `test_external.py` — all pre-date this branch. Root cause: tests don't mock HB introspect that Phase 1a startup now calls. Tracked separately; unblocked by updating respx mocks in those test modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)