### PR TITLE
Core+Relay HeartBeat client cutover (POST + Bearer key:secret)

### DIFF
--- a/services/core/src/app.py
+++ b/services/core/src/app.py
@@ -133,6 +133,7 @@ def create_app(config: CoreConfig | None = None) -> FastAPI:
         heartbeat_client = HeartBeatBlobClient(
             base_url=config.heartbeat_url,
             api_key=config.heartbeat_api_key,
+            api_secret=config.heartbeat_api_secret,
             timeout=config.blob_fetch_timeout,
         )
         app.state.heartbeat_client = heartbeat_client

--- a/services/core/src/config.py
+++ b/services/core/src/config.py
@@ -46,6 +46,7 @@ class CoreConfig:
     # ── Upstream services ─────────────────────────────────────────────────
     heartbeat_url: str = "http://localhost:9000"
     heartbeat_api_key: str = ""
+    heartbeat_api_secret: str = ""
     edge_url: str = "http://localhost:8090"
 
     # ── Ingestion (WS1) ───────────────────────────────────────────────────
@@ -162,6 +163,8 @@ class CoreConfig:
             kwargs["heartbeat_url"] = v
         if v := env("HEARTBEAT_API_KEY"):
             kwargs["heartbeat_api_key"] = v
+        if v := env("HEARTBEAT_API_SECRET"):
+            kwargs["heartbeat_api_secret"] = v
         if v := env("EDGE_URL"):
             kwargs["edge_url"] = v
 

--- a/services/core/src/ingestion/heartbeat_client.py
+++ b/services/core/src/ingestion/heartbeat_client.py
@@ -29,6 +29,7 @@ class HeartBeatBlobClient:
         self,
         base_url: str,
         api_key: str = "",
+        api_secret: str = "",
         timeout: float = 30.0,
     ) -> None:
         self._client = httpx.AsyncClient(
@@ -37,6 +38,16 @@ class HeartBeatBlobClient:
             limits=httpx.Limits(max_connections=20),
         )
         self._api_key = api_key
+        self._api_secret = api_secret
+
+    def _auth_headers(self) -> dict[str, str]:
+        """Build the Authorization header for HeartBeat service auth.
+
+        HeartBeat expects `Bearer {api_key}:{api_secret}`.
+        """
+        if self._api_key and self._api_secret:
+            return {"Authorization": f"Bearer {self._api_key}:{self._api_secret}"}
+        return {}
 
     async def upload_blob(
         self,
@@ -63,9 +74,7 @@ class HeartBeatBlobClient:
         Raises:
             ExternalServiceError: If HeartBeat is unreachable or returns error.
         """
-        headers: dict[str, str] = {}
-        if self._api_key:
-            headers["Authorization"] = f"Bearer {self._api_key}"
+        headers: dict[str, str] = self._auth_headers()
 
         files = {"file": (filename, data, content_type)}
         form_data: dict[str, str] = {"blob_uuid": blob_uuid}
@@ -128,21 +137,21 @@ class HeartBeatBlobClient:
         """
         Download file bytes from HeartBeat.
 
-        GET /api/blobs/{blob_uuid}/download
+        POST /api/blobs/download with {"blob_uuid": ...} in the body.
+        (HeartBeat audit C-1: blob_uuid must not appear in URLs.)
 
         Retries 3x with exponential backoff on 500/502/503/timeout.
         Raises NotFoundError on 404/410 (no retry).
         Raises ExternalServiceError after exhausting retries.
         """
-        headers: dict[str, str] = {}
-        if self._api_key:
-            headers["Authorization"] = f"Bearer {self._api_key}"
+        headers: dict[str, str] = self._auth_headers()
 
         last_error: Exception | None = None
         for attempt in range(_MAX_RETRIES):
             try:
-                resp = await self._client.get(
-                    f"/api/blobs/{blob_uuid}/download",
+                resp = await self._client.post(
+                    "/api/blobs/download",
+                    json={"blob_uuid": blob_uuid},
                     headers=headers,
                 )
 
@@ -194,19 +203,19 @@ class HeartBeatBlobClient:
         """
         Fetch full tenant config from HeartBeat config.db.
 
-        GET /api/v1/heartbeat/config
+        POST /api/v1/heartbeat/config (HeartBeat audit C-2: this response
+        contains SMTP credentials, FIRS keys, and NAS config — must travel
+        over POST with mandatory service auth, never GET).
 
         Retries 3x with exponential backoff on 5xx.
         Raises ExternalServiceError on final failure.
         """
-        headers: dict[str, str] = {}
-        if self._api_key:
-            headers["Authorization"] = f"Bearer {self._api_key}"
+        headers: dict[str, str] = self._auth_headers()
 
         last_error: Exception | None = None
         for attempt in range(_MAX_RETRIES):
             try:
-                resp = await self._client.get(
+                resp = await self._client.post(
                     "/api/v1/heartbeat/config",
                     headers=headers,
                 )
@@ -259,8 +268,7 @@ class HeartBeatBlobClient:
         Non-fatal: returns None and logs warning on final failure.
         """
         headers: dict[str, str] = {"Content-Type": "application/json"}
-        if self._api_key:
-            headers["Authorization"] = f"Bearer {self._api_key}"
+        headers.update(self._auth_headers())
 
         payload: dict = {"status": status}
         if processing_stage:

--- a/services/core/tests/ws1/unit/test_heartbeat_client.py
+++ b/services/core/tests/ws1/unit/test_heartbeat_client.py
@@ -10,14 +10,14 @@ from src.ingestion.heartbeat_client import HeartBeatBlobClient
 
 @pytest.fixture
 def client():
-    return HeartBeatBlobClient(base_url="http://heartbeat:9000", api_key="test-key")
+    return HeartBeatBlobClient(base_url="http://heartbeat:9000", api_key="test-key", api_secret="test-secret")
 
 
 class TestFetchBlob:
     @respx.mock
     @pytest.mark.asyncio
     async def test_success(self, client):
-        respx.get("http://heartbeat:9000/api/blobs/uuid-1/download").mock(
+        respx.post("http://heartbeat:9000/api/blobs/download").mock(
             return_value=httpx.Response(
                 200,
                 content=b"file content",
@@ -37,7 +37,7 @@ class TestFetchBlob:
     @respx.mock
     @pytest.mark.asyncio
     async def test_404_not_found(self, client):
-        respx.get("http://heartbeat:9000/api/blobs/uuid-1/download").mock(
+        respx.post("http://heartbeat:9000/api/blobs/download").mock(
             return_value=httpx.Response(404)
         )
         with pytest.raises(NotFoundError):
@@ -46,7 +46,7 @@ class TestFetchBlob:
     @respx.mock
     @pytest.mark.asyncio
     async def test_410_error_state(self, client):
-        respx.get("http://heartbeat:9000/api/blobs/uuid-1/download").mock(
+        respx.post("http://heartbeat:9000/api/blobs/download").mock(
             return_value=httpx.Response(410)
         )
         with pytest.raises(NotFoundError, match="error state"):
@@ -55,7 +55,7 @@ class TestFetchBlob:
     @respx.mock
     @pytest.mark.asyncio
     async def test_500_retries_then_fails(self, client):
-        route = respx.get("http://heartbeat:9000/api/blobs/uuid-1/download").mock(
+        route = respx.post("http://heartbeat:9000/api/blobs/download").mock(
             return_value=httpx.Response(500)
         )
         with pytest.raises(ExternalServiceError):
@@ -65,17 +65,17 @@ class TestFetchBlob:
     @respx.mock
     @pytest.mark.asyncio
     async def test_auth_header_sent(self, client):
-        respx.get("http://heartbeat:9000/api/blobs/uuid-1/download").mock(
+        respx.post("http://heartbeat:9000/api/blobs/download").mock(
             return_value=httpx.Response(200, content=b"data", headers={"content-type": "text/plain"})
         )
         await client.fetch_blob("uuid-1")
         request = respx.calls[0].request
-        assert request.headers["authorization"] == "Bearer test-key"
+        assert request.headers["authorization"] == "Bearer test-key:test-secret"
 
     @respx.mock
     @pytest.mark.asyncio
     async def test_empty_filename_fallback(self, client):
-        respx.get("http://heartbeat:9000/api/blobs/uuid-1/download").mock(
+        respx.post("http://heartbeat:9000/api/blobs/download").mock(
             return_value=httpx.Response(200, content=b"data", headers={"content-type": "text/plain"})
         )
         resp = await client.fetch_blob("uuid-1")

--- a/services/core/tests/ws1/unit/test_heartbeat_status.py
+++ b/services/core/tests/ws1/unit/test_heartbeat_status.py
@@ -30,7 +30,7 @@ STATUS_URL = f"/api/v1/heartbeat/blob/{BLOB_UUID}/status"
 
 @pytest.fixture
 def client():
-    return HeartBeatBlobClient(base_url=BASE_URL, api_key="test-key", timeout=5.0)
+    return HeartBeatBlobClient(base_url=BASE_URL, api_key="test-key", api_secret="test-secret", timeout=5.0)
 
 
 @pytest.mark.asyncio
@@ -46,7 +46,7 @@ class TestUpdateBlobStatus:
 
         assert result == {"ok": True}
         request = respx.calls.last.request
-        assert request.headers["authorization"] == "Bearer test-key"
+        assert request.headers["authorization"] == "Bearer test-key:test-secret"
 
     @respx.mock
     async def test_payload_includes_all_fields(self, client):

--- a/services/relay/src/clients/heartbeat.py
+++ b/services/relay/src/clients/heartbeat.py
@@ -13,11 +13,13 @@ HeartBeat is Relay's PRIMARY upstream — it handles:
     - Service health monitoring (HeartBeat keeps services alive)
     - Platform services (Transforma module config)
 
-Auth model:
+Auth model (post-audit-2026-04-25):
     - Blob write/register: Optional Authorization: Bearer {user_jwt}
       (HeartBeat validates JWT in-process via Ed25519 if present)
-    - Dedup, limits, audit, metrics: No auth (internal service calls)
-    - Transforma config: Authorization: Bearer {api_key}:{api_secret}
+    - Dedup check, daily limits, tenant config, transforma config: mandatory
+      Authorization: Bearer {api_key}:{api_secret} (service credentials)
+    - Audit log, metrics report: No auth (legacy fire-and-forget paths;
+      may tighten in a later audit pass)
     - Health: No auth
 
 Audit logging and metrics are fire-and-forget: failures are logged
@@ -55,11 +57,11 @@ class HeartBeatClient(BaseClient):
         POST /api/blobs/register     → Register blob metadata (JSON)
 
         # Deduplication
-        GET  /api/dedup/check        → Check for duplicate hash
+        POST /api/dedup/check        → Check for duplicate hash
         POST /api/dedup/record       → Record processed hash
 
         # Limits
-        GET  /api/limits/daily       → Check daily usage limit
+        POST /api/limits/daily/check → Check daily usage limit
 
         # Audit (immutable, append-only)
         POST /api/audit/log          → Log audit event
@@ -67,8 +69,11 @@ class HeartBeatClient(BaseClient):
         # Metrics
         POST /api/metrics/report     → Report ingestion metrics
 
+        # Tenant config
+        POST /api/v1/heartbeat/config → Full tenant config bundle
+
         # Platform
-        GET  /api/platform/transforma/config → Transforma module config
+        POST /api/platform/transforma/config → Transforma module config
 
         # Health
         GET  /health                 → Health check
@@ -225,7 +230,10 @@ class HeartBeatClient(BaseClient):
         """
         Check if a file hash has been seen before.
 
-        GET /api/dedup/check?file_hash={64-char SHA256}
+        POST /api/dedup/check  JSON: {file_hash}
+        Authorization: Bearer {api_key}:{api_secret}
+        (HeartBeat audit M-1: SHA-256 is a content identifier and must
+        not appear in URLs/logs.)
 
         Args:
             file_hash: SHA256 hex digest of file data.
@@ -236,13 +244,17 @@ class HeartBeatClient(BaseClient):
         async def _check():
             http = self._get_http()
             headers = self.get_trace_headers()
+            if self._service_api_key and self._service_api_secret:
+                headers["Authorization"] = (
+                    f"Bearer {self._service_api_key}:{self._service_api_secret}"
+                )
 
             self._calls.append(("check_duplicate", file_hash))
 
             try:
-                resp = await http.get(
+                resp = await http.post(
                     "/api/dedup/check",
-                    params={"file_hash": file_hash},
+                    json={"file_hash": file_hash},
                     headers=headers,
                 )
             except httpx.ConnectError as e:
@@ -309,7 +321,9 @@ class HeartBeatClient(BaseClient):
         """
         Check if company has exceeded daily upload limit.
 
-        GET /api/limits/daily?company_id=&file_count=
+        POST /api/limits/daily/check  JSON: {company_id, file_count}
+        Authorization: Bearer {api_key}:{api_secret}
+        (HeartBeat audit C-4: company_id must travel in body, not URL.)
 
         Args:
             company_id: Company identifier.
@@ -321,16 +335,17 @@ class HeartBeatClient(BaseClient):
         async def _check():
             http = self._get_http()
             headers = self.get_trace_headers()
+            if self._service_api_key and self._service_api_secret:
+                headers["Authorization"] = (
+                    f"Bearer {self._service_api_key}:{self._service_api_secret}"
+                )
 
             self._calls.append(("check_daily_limit", company_id, file_count))
 
             try:
-                resp = await http.get(
-                    "/api/limits/daily",
-                    params={
-                        "company_id": company_id,
-                        "file_count": file_count,
-                    },
+                resp = await http.post(
+                    "/api/limits/daily/check",
+                    json={"company_id": company_id, "file_count": file_count},
                     headers=headers,
                 )
             except httpx.ConnectError as e:
@@ -426,8 +441,10 @@ class HeartBeatClient(BaseClient):
         """
         Fetch full tenant config from HeartBeat.
 
-        GET /api/v1/heartbeat/config
+        POST /api/v1/heartbeat/config
         Auth: Bearer {api_key}:{api_secret}
+        (HeartBeat audit C-2: response contains SMTP credentials, FIRS
+        keys, NAS config — must travel via POST.)
 
         Returns full config dict (tenant, firs, endpoints, tier_limits, etc.)
         Used at startup to populate ConfigCache.
@@ -449,7 +466,7 @@ class HeartBeatClient(BaseClient):
             self._calls.append(("fetch_config",))
 
             try:
-                resp = await http.get(
+                resp = await http.post(
                     "/api/v1/heartbeat/config",
                     headers=headers,
                 )
@@ -627,8 +644,10 @@ class HeartBeatClient(BaseClient):
         """
         Fetch Transforma modules and FIRS service keys from HeartBeat.
 
-        GET /api/platform/transforma/config
+        POST /api/platform/transforma/config
         Authorization: Bearer {api_key}:{api_secret}
+        (HeartBeat audit M-7: response contains FIRS keys; POST keeps it
+        out of HTTP caches.)
 
         Called by TransformaModuleCache at startup and every 12 hours.
 
@@ -648,7 +667,7 @@ class HeartBeatClient(BaseClient):
             self._calls.append(("get_transforma_config",))
 
             try:
-                resp = await http.get(
+                resp = await http.post(
                     "/api/platform/transforma/config",
                     headers=headers,
                 )

--- a/services/relay/tests/api/conftest.py
+++ b/services/relay/tests/api/conftest.py
@@ -77,7 +77,7 @@ def mock_heartbeat_http():
     """
     with respx.mock:
         # Startup: module_cache.load_all() calls this
-        respx.get("http://localhost:9000/api/platform/transforma/config").mock(
+        respx.post("http://localhost:9000/api/platform/transforma/config").mock(
             return_value=httpx.Response(200, json=TRANSFORMA_CONFIG_RESPONSE)
         )
 
@@ -88,7 +88,7 @@ def mock_heartbeat_http():
 
         # Ingestion pipeline: dedup check, blob write, dedup record, register,
         # daily limit, audit, metrics — mock all with success responses
-        respx.get("http://localhost:9000/api/dedup/check").mock(
+        respx.post("http://localhost:9000/api/dedup/check").mock(
             return_value=httpx.Response(200, json={
                 "is_duplicate": False,
                 "file_hash": "mock",
@@ -122,7 +122,7 @@ def mock_heartbeat_http():
             })
         )
 
-        respx.get("http://localhost:9000/api/limits/daily").mock(
+        respx.post("http://localhost:9000/api/limits/daily/check").mock(
             return_value=httpx.Response(200, json={
                 "company_id": "mock",
                 "files_today": 0,

--- a/services/relay/tests/clients/test_heartbeat.py
+++ b/services/relay/tests/clients/test_heartbeat.py
@@ -184,7 +184,7 @@ class TestHeartBeatCheckDuplicate:
     @respx.mock
     @pytest.mark.asyncio
     async def test_not_duplicate(self, hb_client):
-        respx.get(f"{HEARTBEAT_URL}/api/dedup/check").mock(
+        respx.post(f"{HEARTBEAT_URL}/api/dedup/check").mock(
             return_value=Response(200, json={
                 "is_duplicate": False,
                 "file_hash": "abc123",
@@ -200,7 +200,7 @@ class TestHeartBeatCheckDuplicate:
     @respx.mock
     @pytest.mark.asyncio
     async def test_is_duplicate(self, hb_client):
-        respx.get(f"{HEARTBEAT_URL}/api/dedup/check").mock(
+        respx.post(f"{HEARTBEAT_URL}/api/dedup/check").mock(
             return_value=Response(200, json={
                 "is_duplicate": True,
                 "file_hash": "abc123",
@@ -215,7 +215,7 @@ class TestHeartBeatCheckDuplicate:
     @respx.mock
     @pytest.mark.asyncio
     async def test_check_duplicate_server_error(self, hb_client):
-        respx.get(f"{HEARTBEAT_URL}/api/dedup/check").mock(
+        respx.post(f"{HEARTBEAT_URL}/api/dedup/check").mock(
             return_value=Response(500, text="DB error")
         )
 
@@ -255,7 +255,7 @@ class TestHeartBeatDailyLimit:
     @respx.mock
     @pytest.mark.asyncio
     async def test_under_limit(self, hb_client):
-        respx.get(f"{HEARTBEAT_URL}/api/limits/daily").mock(
+        respx.post(f"{HEARTBEAT_URL}/api/limits/daily/check").mock(
             return_value=Response(200, json={
                 "company_id": "company-001",
                 "files_today": 10,
@@ -272,7 +272,7 @@ class TestHeartBeatDailyLimit:
     @respx.mock
     @pytest.mark.asyncio
     async def test_limit_reached(self, hb_client):
-        respx.get(f"{HEARTBEAT_URL}/api/limits/daily").mock(
+        respx.post(f"{HEARTBEAT_URL}/api/limits/daily/check").mock(
             return_value=Response(200, json={
                 "company_id": "company-001",
                 "files_today": 500,
@@ -593,7 +593,7 @@ class TestHeartBeatTransformaConfig:
             },
         }
 
-        route = respx.get(f"{HEARTBEAT_URL}/api/platform/transforma/config").mock(
+        route = respx.post(f"{HEARTBEAT_URL}/api/platform/transforma/config").mock(
             return_value=Response(200, json=config_data)
         )
 
@@ -618,7 +618,7 @@ class TestHeartBeatTransformaConfig:
             max_attempts=1,
         )
 
-        route = respx.get(f"{HEARTBEAT_URL}/api/platform/transforma/config").mock(
+        route = respx.post(f"{HEARTBEAT_URL}/api/platform/transforma/config").mock(
             return_value=Response(200, json={"modules": [], "service_keys": {}})
         )
 
@@ -630,7 +630,7 @@ class TestHeartBeatTransformaConfig:
     @respx.mock
     @pytest.mark.asyncio
     async def test_get_config_heartbeat_down(self, hb_client):
-        respx.get(f"{HEARTBEAT_URL}/api/platform/transforma/config").mock(
+        respx.post(f"{HEARTBEAT_URL}/api/platform/transforma/config").mock(
             side_effect=ConnectionError("refused")
         )
 


### PR DESCRIPTION
## Summary

Migrates Core and Relay HeartBeat clients to **POST + Bearer key:secret** per the helium-services audit remediation. Companion to [helium-services#16](https://github.com/bob-nzelu/helium-services/pull/16).

## What's inside

**Core (4 files):**
- `services/core/src/config.py` — adds `heartbeat_api_secret` + `CORE_HEARTBEAT_API_SECRET` env loader
- `services/core/src/app.py` — passes the new secret to `HeartBeatBlobClient`
- `services/core/src/ingestion/heartbeat_client.py` — new `_auth_headers()` helper emits `Bearer {api_key}:{api_secret}`; `fetch_blob` → `POST /api/blobs/download`; `fetch_config` → `POST /api/v1/heartbeat/config`; `update_blob_status` uses new auth headers
- `services/core/tests/ws1/unit/test_heartbeat_client.py` + `test_heartbeat_status.py` — respx mocks switched GET→POST + Bearer key:secret assertions

**Relay (3 files):**
- `services/relay/src/clients/heartbeat.py` — `check_duplicate`, `check_daily_limit`, `fetch_config`, `get_transforma_config` all migrated to POST with Bearer service creds; top-of-file docstring + endpoint table updated
- `services/relay/tests/clients/test_heartbeat.py` — respx mocks GET→POST
- `services/relay/tests/api/conftest.py` — autouse fixture POST mocks for all HeartBeat routes

## ⚠️ Hold merge

**Do not merge until [helium-services#16](https://github.com/bob-nzelu/helium-services/pull/16) is merged AND deployed to EC2 #1** (`13.247.224.147`). The new POST + Bearer behaviour requires the server-side endpoints from that PR.

The deprecated GET shims in HeartBeat keep Core/Relay working in the interim, so there's no urgency on this PR — it just needs to land in the right order.

## Deploy order

1. Merge helium-services#16 (audit remediation)
2. Deploy HeartBeat to EC2 #1
3. Verify POST endpoints respond
4. Merge this PR
5. Deploy Core + Relay to EC2 #1

## Test plan

- [ ] CI green
- [ ] After EC2 deploy: end-to-end Float upload succeeds
- [ ] Verify Relay→HeartBeat dedup/limits/config calls all hit POST routes with Bearer creds (200)
- [ ] Verify Core→HeartBeat fetch_blob/fetch_config/update_blob_status all hit POST routes with Bearer creds (200)
- [ ] No 401/404/405 on any HeartBeat call from Core or Relay logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)