### PR TITLE
fix(deploy): rename HEARTBEAT_TEST_HARNESS_ENABLED to HEARTBEAT_DEMO_MODE

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,12 @@ services:
       - HEARTBEAT_AUTO_MIGRATE=true
       - HEARTBEAT_TIER=test
       - HEARTBEAT_MAX_CONCURRENT_SESSIONS=3
-      - HEARTBEAT_TEST_HARNESS_ENABLED=true
+      # HEARTBEAT_DEMO_MODE (not HEARTBEAT_TEST_HARNESS_ENABLED) is the gate
+      # the HeartBeat code reads in src/auth/test_harness_manager.py. The
+      # name reflects the security intent: demo-mode is the hard gate that
+      # production deployments never set, so leaked harness keys cannot
+      # mount /api/test/* against a production instance.
+      - HEARTBEAT_DEMO_MODE=true
       - HEARTBEAT_TEST_HARNESS_KEY_HASH=786ac05ff1f90d133056376fa0a65188cab837fe4450d47d1be924bd54d017d3
       - HEARTBEAT_PG_HOST=postgres
       - HEARTBEAT_PG_PORT=5432

--- a/docs/HEARTBEAT_AUTH_SESSION_HANDOFF.md
+++ b/docs/HEARTBEAT_AUTH_SESSION_HANDOFF.md
@@ -152,7 +152,7 @@ GET  /api/auth/sessions               — list active sessions for current user
    - `POST /api/test/sse/emit` — push custom SSE event
    - `POST /api/test/config/override` — temporarily override config
    - `GET /api/test/state` — dump system state for debugging
-4. Register conditionally: `HEARTBEAT_TEST_HARNESS_ENABLED=true`
+4. Register conditionally: `HEARTBEAT_DEMO_MODE=true` AND `HEARTBEAT_TEST_HARNESS_KEY_HASH=<sha256-hex>` (the gate `HEARTBEAT_TEST_HARNESS_ENABLED` mentioned in earlier drafts was never wired into code)
 5. All test operations are audit-logged
 
 ### Task 7: Update Engine (Foundation)

--- a/docs/HEARTBEAT_HARMONIZATION_HANDOFF.md
+++ b/docs/HEARTBEAT_HARMONIZATION_HANDOFF.md
@@ -124,7 +124,7 @@ Audit reality: `Pronalytics\helium-multitenant-demo\services\heartbeat` (NEW) is
 8. **`services/heartbeat/src/api/test_harness/__init__.py`** (new).
 9. **`services/heartbeat/src/api/admin.py`** (61 LOC, new file) — update engine stubs returning 501 except history ([]).
 10. **`services/heartbeat/src/api/mock_auth.py`** (310 LOC) — mock auth router, activated by `HEARTBEAT_MOCK_AUTH=true`.
-11. **`services/heartbeat/src/main.py`** — conditional router registration block and `HEARTBEAT_TEST_HARNESS_ENABLED` gate for test harness routes.
+11. **`services/heartbeat/src/main.py`** — conditional router registration block; gate is `HEARTBEAT_DEMO_MODE=true` AND `HEARTBEAT_TEST_HARNESS_KEY_HASH` set. (Earlier drafts of this doc said `HEARTBEAT_TEST_HARNESS_ENABLED` — that name was never wired into the code.)
 
 **Deploy artefacts to keep in the demo repo (not ported):**
 

--- a/docs/HELIUM_DEPLOYMENT_ARCHITECTURE.md
+++ b/docs/HELIUM_DEPLOYMENT_ARCHITECTURE.md
@@ -325,7 +325,7 @@ Physical file on developer's laptop (`~/.helium/test_harness_key`) enables privi
 
 **Endpoints:** `/api/test/*` (auth/reset, data/seed, data/clear, pipeline/trigger, sse/emit, config/override)
 
-**Activation:** `HEARTBEAT_TEST_HARNESS_ENABLED=true` env var on HeartBeat.
+**Activation:** `HEARTBEAT_DEMO_MODE=true` AND `HEARTBEAT_TEST_HARNESS_KEY_HASH=<sha256-hex>` env vars on HeartBeat. (Earlier docs wrote `HEARTBEAT_TEST_HARNESS_ENABLED` — that variable name was never wired into the code; the canonical name has always been `HEARTBEAT_DEMO_MODE`. The "demo mode" framing is intentional: production deployments never set it, so a leaked key cannot mount `/api/test/*` against a production instance.)
 
 **Security:** Code is identical in dev and production. No key file = no test mode activates. HMAC-signed requests, constant-time validation, full audit logging.
 


### PR DESCRIPTION
Float Phase 2 ask: `/api/test/*` returns 404 on EC2 #1 because docker-compose.yml sets `HEARTBEAT_TEST_HARNESS_ENABLED=true` while the code reads `HEARTBEAT_DEMO_MODE`. Deploy/code mismatch from PR #11 nobody caught until now.`n`n`demo_mode` name is intentional in code: production never sets it, so a leaked harness key cannot mount `/api/test/*` against a production instance. Renaming preserves that security model.`n`ndocker-compose.yml is the fix; three handoff docs updated.`n`nAfter merge:`ncd /home/ubuntu/helium-multitenant-demo && git pull && sudo docker compose up -d heartbeat