### PR TITLE
chore: add .gitattributes to canonicalise line endings (closes PENDING_WORK item 3)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Normalise line endings on commit so EC2 stashes / Windows edits do not
+# produce CRLF↔LF noise that masquerades as substantive diffs.
+#
+# Background: the 2026-04-27 phase-1b-relay-hotpatch stash on EC2 #1
+# captured 828 insertions / 828 deletions across services/relay/src/api/
+# that turned out to be pure CRLF churn — no real changes.
+# A .gitattributes prevents the recurrence by canonicalising every
+# committed file to LF.
+
+*               text=auto eol=lf
+
+# Binary types (do not normalise)
+*.png           binary
+*.jpg           binary
+*.jpeg          binary
+*.gif           binary
+*.ico           binary
+*.pdf           binary
+*.zip           binary
+*.gz            binary
+*.tar           binary
+*.dump          binary
+*.db            binary
+*.sqlite        binary
+*.sqlite3       binary


### PR DESCRIPTION
## Summary

The 2026-04-27 `phase-1b-relay-hotpatch-2026-04-27` stash on EC2 #1 was logged in [helium-services PENDING_WORK item 3](https://github.com/bob-nzelu/helium-services/blob/master/HeartBeat/Documentation/PENDING_WORK_2026_04_28.md) as real tech debt — three Relay files allegedly carrying combined-auth-dispatcher hotpatches that never went through a PR. Investigating today:

- `git diff --ignore-all-space` against the popped stash → **0 lines**
- `file services/relay/src/api/app.py` → **CRLF line terminators**
- `file` against HEAD → **LF (Unix)**

The 828 insertions / 828 deletions are 100% line-ending churn. The combined-auth-dispatcher work was already merged via [PR #9](https://github.com/bob-nzelu/helium-multitenant-demo/pull/9); the stash was a ghost.

This PR adds `.gitattributes` with `text=auto eol=lf` so any future Windows edit or EC2 stash gets canonicalised to LF on commit, preventing the same ghost diff from recurring.

## What was done on EC2 to confirm

```bash
ssh ubuntu@13.247.224.147
cd /home/ubuntu/helium-multitenant-demo
git stash pop                         # popped the phase-1b stash
git diff --ignore-all-space | wc -l   # → 0
file services/relay/src/api/app.py     # → CRLF
git show HEAD:...app.py | file -       # → LF
git checkout -- services/relay/src/api/  # discarded the CRLF working tree
```

Stash dropped. EC2 working tree is now clean against `main`.

## Test plan

- [x] No code changes — just `.gitattributes`. CI should be green.
- [ ] Future commits from Windows machines should ship as LF in git regardless of working-tree line ending.

## Follow-up in helium-services

A separate doc-only commit in helium-services will mark PENDING_WORK item 3 as closed (no real hotpatches, ghost diff explained).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)
