### PR TITLE
chore(phase-3b): mount signed license JSONs into shared heartbeat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist/
 build/
 desktop.ini
 Thumbs.db
+licenses/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,9 +84,15 @@ services:
       - HEARTBEAT_PG_USER=${PG_USER:-helium}
       - HEARTBEAT_PG_PASSWORD=${PG_PASSWORD:-helium_demo_2026}
       - HEARTBEAT_PG_DATABASE=${PG_DATABASE:-helium}
+      # Phase 3B: signed license verification (read abbey license while shared container)
+      - HEARTBEAT_LICENSE_PATH=/etc/helium/abbey/license.json
+      - HEARTBEAT_LICENSE_REQUIRED=true
     volumes:
       - heartbeat-data:/app/databases
       - heartbeat-blobs:/app/data/blobs
+      - ./licenses/abbey.license.json:/etc/helium/abbey/license.json:ro
+      - ./licenses/adansi.license.json:/etc/helium/adansi/license.json:ro
+      - ./licenses/redeploy-probe.license.json:/etc/helium/redeploy-probe/license.json:ro
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Phase 3B retired `license.db` in favor of an ECDSA-signed JSON file at `/etc/helium/<tenant>/license.json`. The shared heartbeat container needs the env vars + read-only volume mounts so it can verify a license at startup. Already running this way on EC2 #1 since Phase 3B cutover.

## Changes

- `HEARTBEAT_LICENSE_PATH=/etc/helium/abbey/license.json` (shared container reads abbey's license; Phase 4 per-tenant containers will each read their own)
- `HEARTBEAT_LICENSE_REQUIRED=true` (explicit, matches the default in helium-services)
- Three read-only mounts: `./licenses/<slug>.license.json:/etc/helium/<slug>/license.json:ro`
- `licenses/` added to `.gitignore` — signed license files ship out-of-band per [PRODUCTION_READINESS.md](https://github.com/bob-nzelu/helium-services/blob/master/HeartBeat/Documentation/PRODUCTION_READINESS.md)

## Verification (already live on EC2 #1)

```
src.license.loader - INFO - License loaded: tenant=abbey tier=pro key_id=helium-license-2026 expires=2030-12-31T00:00:00Z state=valid
src.license.loader - WARNING - PRODUCTION READINESS: license tenant_slug='abbey' is a Phase 3B TEST license (root-credential signed). See Documentation/PRODUCTION_READINESS.md before treating this deployment as production.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)