### PR TITLE
chore(deploy): wire HEARTBEAT_REDIS_URL for HMAC s2s nonce store

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,12 @@ services:
       # Phase 3B: signed license verification (read abbey license while shared container)
       - HEARTBEAT_LICENSE_PATH=/etc/helium/abbey/license.json
       - HEARTBEAT_LICENSE_REQUIRED=true
+      # HMAC s2s nonce dedup store (helium-services PR #100 — HMAC_S2S_MIGRATION_SPEC §6).
+      # HB defaults to redis://127.0.0.1:6379/0 which won't resolve inside the
+      # heartbeat container; explicit redis://redis:6379/0 points at the
+      # shared Redis service. Required for HB to accept any s2s HMAC traffic;
+      # without this the nonce store fail-closes 503 NONCE_STORE_UNAVAILABLE.
+      - HEARTBEAT_REDIS_URL=redis://redis:6379/0
     volumes:
       - heartbeat-data:/app/databases
       - heartbeat-blobs:/app/data/blobs
@@ -95,6 +101,8 @@ services:
       - ./licenses/redeploy-probe.license.json:/etc/helium/redeploy-probe/license.json:ro
     depends_on:
       postgres:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "python", "-c", "import httpx; httpx.get('http://localhost:9000/health')"]


### PR DESCRIPTION
## Summary
- Pairs with [`helium-services#100`](https://github.com/bob-nzelu/helium-services/pull/100) (HMAC s2s cutover).
- HB's nonce store defaults to `redis://127.0.0.1:6379/0` — won't resolve inside the heartbeat container. Set `HEARTBEAT_REDIS_URL=redis://redis:6379/0` explicitly, mirroring the existing `RELAY_REDIS_URL` line.
- Add `redis` to HB's `depends_on` with `service_healthy` condition.

Without this, every s2s HMAC call would fail fast with 503 `NONCE_STORE_UNAVAILABLE` (intentionally fail-closed per spec §6.3).

## Deploy ordering
1. Merge this PR
2. Merge helium-services#100
3. SSH EC2; pull both repos; `docker compose build heartbeat && docker compose up -d heartbeat`

## Test plan
- [ ] After deploy: `docker compose logs heartbeat | grep "Redis nonce store connected"` shows the URL
- [ ] Bearer caller hits HB → 401 `BEARER_S2S_REMOVED`
- [ ] HMAC caller hits HB → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)