### PR TITLE
feat(relay): CSSV1 R9 — defensive coding + alarming counters (S1 chip 1/4)

### DIFF
--- a/services/relay/src/api/app.py
+++ b/services/relay/src/api/app.py
@@ -26,6 +26,10 @@ from ..core.irn import IRNGenerator
 from ..core.module_cache import TransformaModuleCache
 from ..core.qr import QRGenerator
 from ..errors import RelayError
+from ..observability.startup_checks import (
+    check_clock_skew_against_heartbeat,
+    validate_signing_key_shape,
+)
 from ..services.bulk import BulkService
 from ..services.external import ExternalService
 from ..services.ingestion import IngestionService
@@ -84,6 +88,13 @@ def create_app(
         """Startup: load module cache. Shutdown: cleanup."""
         # ── Startup ──────────────────────────────────────────────────
         logger.info(f"Relay-API starting — {config.instance_id}:{config.port}")
+
+        # CSSV1 R9.1 + R9.2 — defensive startup checks before any HB
+        # call. Bail loudly on a malformed signing key (R9.1) or a
+        # major clock skew (R9.2); soft-warn on degraded dev mode +
+        # transient HB unreachability.
+        validate_signing_key_shape(config.heartbeat_s2s_signing_key)
+        await check_clock_skew_against_heartbeat(config.heartbeat_api_url)
 
         # Clients — HMAC s2s post-cutover 2026-05-08 (HMAC_S2S_MIGRATION_SPEC).
         # The signing key comes from RELAY_S2S_SIGNING_KEY (config field

--- a/services/relay/src/api/routes/metrics.py
+++ b/services/relay/src/api/routes/metrics.py
@@ -1,20 +1,62 @@
 """
 GET /metrics — Prometheus metrics endpoint (Decision 5A).
 
-Phase 1 stub: returns basic service info metrics in Prometheus exposition format.
-Phase 2 will add prometheus_client counters/histograms for real request tracking.
+Returns basic service info gauges (instance, up, module-cache, redis)
+plus the in-memory counters tracked by ``observability.counters``
+(per CSSV1 R9 — bearer-removed alarm + future R-chip placeholders).
 
-No authentication required (standard for /metrics endpoints).
+Phase 2 will swap the hand-built exposition for ``prometheus_client``
+once the counter set graduates from "alarm rates" to "request
+histograms" (CSSV1 R4 + R8 turn the placeholder counters into proper
+histograms).
+
+No authentication required (standard for /metrics endpoints; allowed
+by the CLAUDE.md golden-rule carve-out for unauth health/metrics).
 """
 
 import logging
+from typing import List
 
 from fastapi import APIRouter, Request
 from fastapi.responses import PlainTextResponse
 
+from ...observability import counters
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _format_labels(labels: dict) -> str:
+    """Render a {k: v} dict as a Prometheus label suffix `{k="v",...}`."""
+    if not labels:
+        return ""
+    parts = ",".join(f'{k}="{v}"' for k, v in sorted(labels.items()))
+    return "{" + parts + "}"
+
+
+def _emit_counters() -> List[str]:
+    """Render ``observability.counters`` as Prometheus exposition lines.
+
+    Emits one ``# HELP`` + ``# TYPE`` header per counter name in
+    :data:`counters.COUNTER_HELP`, then a sample line per
+    ``(name, labels)`` combination tracked. Counters with no observed
+    samples emit only the header — that's fine; Prometheus handles
+    zero-sample exposition.
+    """
+    # Bucket samples by name so we emit one HELP/TYPE block + many lines.
+    by_name: dict = {}
+    for name, labels, value in counters.get_all():
+        by_name.setdefault(name, []).append((labels, value))
+
+    out: List[str] = []
+    for name, (help_text, type_str) in counters.COUNTER_HELP.items():
+        out.append(f"# HELP {name} {help_text}")
+        out.append(f"# TYPE {name} {type_str}")
+        for labels, value in by_name.get(name, []):
+            out.append(f"{name}{_format_labels(labels)} {value}")
+        out.append("")
+    return out
 
 
 @router.get(
@@ -26,7 +68,7 @@ async def metrics(request: Request):
     """
     Export Prometheus-format metrics.
 
-    Phase 1 stub — returns service info and health gauges.
+    Service-info gauges + CSSV1 counters (alarming + placeholders).
     """
     config = request.app.state.config
     module_cache = request.app.state.module_cache
@@ -35,7 +77,7 @@ async def metrics(request: Request):
     module_cache_up = 1 if module_cache.is_loaded else 0
     redis_up = 1 if redis.is_available else 0
 
-    lines = [
+    lines: List[str] = [
         "# HELP helium_relay_info Relay service information",
         "# TYPE helium_relay_info gauge",
         f'helium_relay_info{{instance_id="{config.instance_id}",version="{request.app.version}"}} 1',
@@ -53,6 +95,9 @@ async def metrics(request: Request):
         f"helium_relay_redis_connected {redis_up}",
         "",
     ]
+
+    # Append in-memory counters (CSSV1 R9 + future placeholders).
+    lines.extend(_emit_counters())
 
     return PlainTextResponse(
         content="\n".join(lines) + "\n",

--- a/services/relay/src/clients/heartbeat.py
+++ b/services/relay/src/clients/heartbeat.py
@@ -56,8 +56,15 @@ from ..errors import (
     JWTRejectedError,
     TransientError,
 )
+from ..observability import counters
 
 logger = logging.getLogger(__name__)
+
+
+# CSSV1 R9.3 — alarm signal. If HB ever returns this code from a Relay
+# call, a Relay code path is still sending the dead Bearer s2s form.
+# Rate >0 after Phase 0 catchup (2026-05-09) is a regression.
+_BEARER_REMOVED_CODE = "BEARER_S2S_REMOVED"
 
 
 class HeartBeatClient(BaseClient):
@@ -199,6 +206,7 @@ class HeartBeatClient(BaseClient):
             return
 
         if resp.status_code == 401:
+            self._check_bearer_removed_alarm(resp, context)
             raise JWTRejectedError(
                 message=f"HeartBeat rejected JWT on {context}: {resp.text}"
             )
@@ -212,6 +220,47 @@ class HeartBeatClient(BaseClient):
         # 4xx other than 401 — permanent error, wrap as HeartBeatUnavailable
         raise HeartBeatUnavailableError(
             message=f"HeartBeat {context} failed ({resp.status_code}): {resp.text}"
+        )
+
+    def _check_bearer_removed_alarm(
+        self, resp: httpx.Response, context: str
+    ) -> None:
+        """Per CSSV1 R9.3 — fire the alarm if HB returns BEARER_S2S_REMOVED.
+
+        HB returns ``401`` with JSON ``{"error_code": "BEARER_S2S_REMOVED"}``
+        when the caller is still sending the dead ``Authorization: Bearer
+        api_key:api_secret`` form. Post-Phase-0 (2026-05-09) Relay should
+        NEVER trigger this — every Relay→HB call goes through
+        :func:`_s2s_headers`. A non-zero rate on
+        ``relay_bearer_removed_received_total`` means a code path slipped
+        back onto the legacy form; ops alarms.
+
+        ERROR-level log + counter increment. Doesn't change the raised
+        exception (still :class:`JWTRejectedError`) — this is purely a
+        side-channel signal.
+        """
+        try:
+            body = resp.json()
+        except Exception:
+            return  # not JSON — definitely not the signed BEARER_S2S_REMOVED shape
+        if not isinstance(body, dict):
+            return
+        if body.get("error_code") != _BEARER_REMOVED_CODE:
+            return
+
+        counters.inc(
+            "relay_bearer_removed_received_total",
+            labels={"endpoint": context},
+        )
+        logger.error(
+            "BEARER_S2S_REMOVED received from HeartBeat — Relay sent the "
+            "dead Bearer s2s form on %s. This is a regression: every "
+            "Relay→HB call should go through build_s2s_hmac_headers(). "
+            "Find the offending caller in the trace and migrate it. "
+            "(Rate alarm: relay_bearer_removed_received_total{endpoint=%r}.)",
+            context,
+            context,
+            extra={"trace_id": self.trace_id},
         )
 
     # ── Blob Storage ───────────────────────────────────────────────────────

--- a/services/relay/src/clients/introspect.py
+++ b/services/relay/src/clients/introspect.py
@@ -37,8 +37,15 @@ from ..errors import (
     HeartBeatUnavailableError,
     JWTRejectedError,
 )
+from ..observability import counters
 
 logger = logging.getLogger(__name__)
+
+
+# CSSV1 R9.3 — see ``clients.heartbeat`` for full rationale. Mirrors the
+# alarm path on the introspect-only HTTP transport (which doesn't share
+# ``HeartBeatClient._raise_for_status``).
+_BEARER_REMOVED_CODE = "BEARER_S2S_REMOVED"
 
 
 @dataclass
@@ -200,6 +207,26 @@ class IntrospectClient:
 
         # Auth-upstream protocol errors: spec §2.4 — fail closed to 502
         if resp.status_code == 401:
+            # CSSV1 R9.3 — alarm if HB returned the BEARER_S2S_REMOVED code.
+            # Means the introspect call shipped Bearer api_key:api_secret
+            # somehow (header builder regression / config drift).
+            try:
+                body = resp.json()
+            except Exception:
+                body = None
+            if isinstance(body, dict) and body.get("error_code") == _BEARER_REMOVED_CODE:
+                counters.inc(
+                    "relay_bearer_removed_received_total",
+                    labels={"endpoint": "introspect"},
+                )
+                logger.error(
+                    "BEARER_S2S_REMOVED received on introspect — Relay sent "
+                    "the dead Bearer s2s form. This is a regression: every "
+                    "introspect call should go through "
+                    "build_s2s_hmac_headers(). (Rate alarm: "
+                    "relay_bearer_removed_received_total{endpoint=\"introspect\"}.)",
+                    extra={"trace_id": trace_id},
+                )
             # Our own service creds are invalid — config error, not user-token issue
             logger.error(
                 "Introspect call rejected with 401 — Relay's own HB s2s "

--- a/services/relay/src/errors.py
+++ b/services/relay/src/errors.py
@@ -300,6 +300,33 @@ class InternalError(RelayError):
         self.original_error = original_error
 
 
+# ── Configuration Error (process-bail at startup) ─────────────────────────
+
+
+class ConfigError(RelayError):
+    """
+    Raised at startup when Relay's configuration is invalid in a way that
+    cannot be safely degraded. Examples:
+
+    - ``RELAY_S2S_SIGNING_KEY`` is not 64 lowercase-hex chars (CSSV1 R9.1)
+    - System clock skew vs HeartBeat exceeds the safe margin (CSSV1 R9.2)
+    - A required env var is missing on a code path that cannot tolerate
+      the empty default
+
+    These should NEVER surface to a request handler. They abort the
+    lifespan startup so the container fails fast and the orchestrator
+    surfaces the misconfiguration in deploy logs rather than mystery
+    401s mid-flight.
+    """
+
+    def __init__(self, message: str):
+        super().__init__(
+            error_code="CONFIG_ERROR",
+            message=message,
+            status_code=500,  # never returned to a client; bails at startup
+        )
+
+
 # ── Transient Errors (500, retryable) ─────────────────────────────────────
 
 

--- a/services/relay/src/observability/__init__.py
+++ b/services/relay/src/observability/__init__.py
@@ -1,0 +1,1 @@
+"""Observability primitives for Relay (counters, metrics helpers)."""

--- a/services/relay/src/observability/counters.py
+++ b/services/relay/src/observability/counters.py
@@ -1,0 +1,115 @@
+"""
+In-memory Prometheus-style counters for Relay.
+
+Phase 1 stub equivalent — process-local counters that the ``/metrics``
+route renders alongside the existing service-info gauges. Lightweight
+on purpose: the ``prometheus_client`` library is a fine drop-in later
+but we don't need it for the alarming-counter shape CSSV1 §R9 demands.
+
+Public API
+----------
+
+``inc(name, labels=None)``
+    Increment the counter ``name`` by 1. ``labels`` is an optional
+    ``{label_key: label_value}`` dict; the ``(name, sorted-labels)``
+    tuple is the unique counter identity. Idempotent across processes
+    (each Relay container has its own dict; ops aggregates at the
+    Prometheus scrape layer).
+
+``get_all() -> Iterable[Tuple[str, Dict[str, str], int]]``
+    Yield every ``(name, labels, value)`` tuple currently tracked.
+    Used by the ``/metrics`` route to render exposition lines.
+
+``reset()``
+    Wipe all counters. Test-only helper. Not exposed via the route.
+
+Counter naming follows the Prometheus convention
+``relay_{namespace}_total`` for monotonically-increasing counters
+(see https://prometheus.io/docs/practices/naming/). Pre-declare the
+HELP + TYPE strings in :data:`COUNTER_HELP` so the exposition has
+those lines even when the counter has zero samples.
+
+Currently tracked counters (CSSV1 R9 + future R-chips):
+
+- ``relay_bearer_removed_received_total{endpoint}`` — incremented
+  whenever a Relay outbound call to HB receives ``401`` with
+  ``error_code="BEARER_S2S_REMOVED"``. Any non-zero rate after Phase 0
+  catchup means a code path is still sending the dead Bearer s2s
+  form; ops alarms.
+- ``relay_amqp_publish_total{routing_key,result}`` — placeholder for
+  CSSV1 R2 (state-only AMQP producer).
+- ``relay_lock_acquire_duration_seconds`` — placeholder for CSSV1 R8.
+- ``relay_status_orchestration_duration_seconds`` — placeholder for
+  CSSV1 R4.
+
+The placeholders are listed in :data:`COUNTER_HELP` so the exposition
+is forward-compatible; their ``inc()`` callsites land in the chips
+that wire them.
+"""
+
+from __future__ import annotations
+
+from threading import Lock
+from typing import Dict, Iterable, Mapping, Optional, Tuple
+
+
+# Map of (name, sorted-label-tuple) → integer count.
+_COUNTERS: Dict[Tuple[str, Tuple[Tuple[str, str], ...]], int] = {}
+_LOCK = Lock()
+
+
+# Pre-declared HELP + TYPE metadata so the exposition has the lines
+# even when the counter hasn't fired yet. The /metrics route reads
+# this dict to emit ``# HELP`` / ``# TYPE`` blocks for every known
+# counter, then iterates :func:`get_all` for the sample lines.
+COUNTER_HELP: Dict[str, Tuple[str, str]] = {
+    # name: (help_text, prometheus_type)
+    "relay_bearer_removed_received_total": (
+        "Count of HB responses with 401 BEARER_S2S_REMOVED received by Relay. "
+        "Non-zero rate = a Relay code path is still sending Bearer s2s.",
+        "counter",
+    ),
+    "relay_amqp_publish_total": (
+        "Count of Relay AMQP publishes to core_queue, labeled by routing_key + result.",
+        "counter",
+    ),
+    "relay_lock_acquire_duration_seconds": (
+        "Histogram of Relay → HB batch_lock acquire durations (placeholder).",
+        "counter",  # placeholder counter; flips to histogram in CSSV1 R8
+    ),
+    "relay_status_orchestration_duration_seconds": (
+        "Histogram of Relay /api/status orchestration durations (placeholder).",
+        "counter",  # placeholder counter; flips to histogram in CSSV1 R4
+    ),
+}
+
+
+def _normalise_labels(labels: Optional[Mapping[str, str]]) -> Tuple[Tuple[str, str], ...]:
+    """Sort-and-tuple the label dict so equivalent dicts hash to the same key."""
+    if not labels:
+        return ()
+    return tuple(sorted((str(k), str(v)) for k, v in labels.items()))
+
+
+def inc(name: str, labels: Optional[Mapping[str, str]] = None) -> None:
+    """Increment counter ``name`` (with optional ``labels``) by 1."""
+    key = (name, _normalise_labels(labels))
+    with _LOCK:
+        _COUNTERS[key] = _COUNTERS.get(key, 0) + 1
+
+
+def get_all() -> Iterable[Tuple[str, Dict[str, str], int]]:
+    """Yield every tracked counter's ``(name, labels_dict, value)`` snapshot."""
+    with _LOCK:
+        snapshot = list(_COUNTERS.items())
+    for (name, labels_tuple), value in snapshot:
+        yield name, dict(labels_tuple), value
+
+
+def reset() -> None:
+    """Wipe all counters. Test-only helper."""
+    with _LOCK:
+        _COUNTERS.clear()
+
+
+__all__ = ["inc", "get_all", "reset", "COUNTER_HELP"]

--- a/services/relay/src/observability/startup_checks.py
+++ b/services/relay/src/observability/startup_checks.py
@@ -1,0 +1,173 @@
+"""
+Startup configuration checks (CSSV1 R9.1 + R9.2).
+
+Two checks fire BEFORE the lifespan yields traffic:
+
+- :func:`validate_signing_key_shape` (R9.1) — confirm
+  ``RELAY_S2S_SIGNING_KEY`` is exactly 64 lowercase-hex chars when it is
+  set. Empty is allowed (degraded dev mode logs WARNING); anything else
+  raises :class:`~src.errors.ConfigError` so the container fails fast.
+
+- :func:`check_clock_skew_against_heartbeat` (R9.2) — best-effort NTP
+  discipline check. Hits HB's ``/health`` and reads the RFC 7231 ``Date``
+  response header, comparing it with local UTC time. Skew > 60 s →
+  :class:`ConfigError`; HB unreachable / ``Date`` unparseable → WARNING,
+  continue (HB may still be cold-starting). Skew is well below HB's
+  300 s ``HMAC_TIMESTAMP_SKEW`` window — a 60 s soft floor catches gross
+  misconfiguration without flapping on small jitter.
+
+Both checks are pure functions (no global state) so they can run in
+arbitrary order from the lifespan and be unit-tested directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from email.utils import parsedate_to_datetime
+from datetime import datetime, timezone
+from typing import Optional
+
+import httpx
+
+from ..errors import ConfigError
+
+logger = logging.getLogger(__name__)
+
+
+# 64 lowercase-hex chars — matches ``secrets.token_hex(32)`` output, the
+# generator HB uses for ``s2s_signing_key`` per HMAC_S2S_MIGRATION_SPEC §5.
+_SIGNING_KEY_RE = re.compile(r"\A[0-9a-f]{64}\Z")
+
+# Soft floor for clock skew before we bail. Well below HB's
+# HMAC_TIMESTAMP_SKEW window (300 s); chosen so transient NTP drift
+# (typically <5 s) doesn't cause false positives but a forgotten-NTP-
+# daemon container (typically minutes off) bails immediately.
+_CLOCK_SKEW_BAIL_S: float = 60.0
+
+
+def validate_signing_key_shape(signing_key: str) -> None:
+    """CSSV1 R9.1 — fail fast on a malformed ``RELAY_S2S_SIGNING_KEY``.
+
+    Empty string is allowed (degraded dev mode, logs WARNING). Anything
+    else must match :data:`_SIGNING_KEY_RE` exactly — uppercase hex,
+    leading/trailing whitespace, prefix like ``hex:``, all reject.
+
+    Raises:
+        ConfigError: When the key is set but malformed. The container
+            fails its health probe so the orchestrator surfaces the
+            misconfiguration in deploy logs rather than mystery 401s
+            mid-flight.
+    """
+    if not signing_key:
+        logger.warning(
+            "RELAY_S2S_SIGNING_KEY is not set. Relay is running in "
+            "DEGRADED dev/test mode — Relay→HB HMAC s2s calls will fail. "
+            "For real deploys, pull the key from HB's startup WARNING log "
+            "per RELAY_NEXT_STEPS_NOTE_2026_05_09 §1.3."
+        )
+        return
+
+    if not _SIGNING_KEY_RE.fullmatch(signing_key):
+        # Don't put the key in the message — it could end up in deploy
+        # logs. Just describe the shape mismatch.
+        raise ConfigError(
+            "RELAY_S2S_SIGNING_KEY is set but does not match the expected "
+            "shape (64 lowercase-hex chars, no prefix, no whitespace). "
+            "The value must equal what HB printed in its startup WARNING "
+            "log verbatim (HMAC_S2S_MIGRATION_SPEC §5)."
+        )
+
+
+async def check_clock_skew_against_heartbeat(
+    heartbeat_api_url: str,
+    *,
+    timeout_s: float = 3.0,
+    bail_threshold_s: float = _CLOCK_SKEW_BAIL_S,
+) -> Optional[float]:
+    """CSSV1 R9.2 — best-effort NTP discipline check.
+
+    Hits ``GET /health`` on HB with a tight timeout, parses the RFC 7231
+    ``Date`` response header, and compares it against ``datetime.now(UTC)``.
+
+    Returns the absolute skew in seconds when both endpoints replied with
+    a parseable ``Date`` header; returns ``None`` when the check could
+    not run (HB unreachable / no ``Date`` / parse fail). Raises
+    :class:`ConfigError` ONLY when HB returned a parseable timestamp and
+    the skew exceeds ``bail_threshold_s``.
+
+    Soft-fail design:
+    - HB unreachable → WARNING + continue (HB may be cold-starting; a
+      hard fail here would create a chicken-and-egg startup ordering bug).
+    - ``Date`` missing/unparseable → WARNING + continue (some proxies
+      strip the header).
+    - Skew > ``bail_threshold_s`` → ConfigError. A ~60 s clock skew at
+      startup virtually guarantees HMAC_TIMESTAMP_SKEW 401s at runtime
+      (HB's window is 300 s but NTP drift compounds); bail loudly so ops
+      sees the misconfig in deploy logs.
+    """
+    url = heartbeat_api_url.rstrip("/") + "/health"
+    try:
+        async with httpx.AsyncClient(timeout=timeout_s) as http:
+            resp = await http.get(url)
+    except (httpx.TimeoutException, httpx.ConnectError, httpx.NetworkError) as e:
+        logger.warning(
+            "NTP discipline check skipped — HB unreachable at %s (%s). "
+            "Relay startup continues; if HMAC_TIMESTAMP_SKEW 401s appear "
+            "post-deploy, run `chronyc tracking` on the container.",
+            url, type(e).__name__,
+        )
+        return None
+    except Exception as e:  # pragma: no cover — defensive
+        logger.warning(
+            "NTP discipline check skipped — unexpected %s on %s: %s",
+            type(e).__name__, url, e,
+        )
+        return None
+
+    date_hdr = resp.headers.get("date") or resp.headers.get("Date")
+    if not date_hdr:
+        logger.warning(
+            "NTP discipline check skipped — HB /health response had no "
+            "Date header (proxy may have stripped it). URL=%s",
+            url,
+        )
+        return None
+
+    try:
+        hb_time = parsedate_to_datetime(date_hdr)
+    except (TypeError, ValueError) as e:
+        logger.warning(
+            "NTP discipline check skipped — could not parse HB Date %r: %s",
+            date_hdr, e,
+        )
+        return None
+
+    if hb_time.tzinfo is None:
+        # parsedate_to_datetime returns naive only when the input was
+        # malformed in subtle ways; treat as UTC-best-effort.
+        hb_time = hb_time.replace(tzinfo=timezone.utc)
+
+    local_now = datetime.now(timezone.utc)
+    skew_s = abs((local_now - hb_time).total_seconds())
+
+    if skew_s > bail_threshold_s:
+        raise ConfigError(
+            f"Clock skew vs HeartBeat is {skew_s:.1f}s "
+            f"(threshold {bail_threshold_s:.0f}s). "
+            "Relay's HMAC s2s headers will be rejected by HB once "
+            "HMAC_TIMESTAMP_SKEW (300s) trips. Confirm chrony/ntpd is "
+            "running on the Relay container before redeploying."
+        )
+
+    logger.info(
+        "NTP discipline OK — Relay clock vs HB skew=%.2fs (threshold=%.0fs)",
+        skew_s, bail_threshold_s,
+    )
+    return skew_s
+
+
+__all__ = [
+    "validate_signing_key_shape",
+    "check_clock_skew_against_heartbeat",
+]

--- a/services/relay/tests/api/test_auth_dispatcher.py
+++ b/services/relay/tests/api/test_auth_dispatcher.py
@@ -1,0 +1,420 @@
+"""
+Tests for the inbound auth dispatcher in ``src/api/deps.py``.
+
+The dispatcher is the inbound-side counterpart of CSSV1 R1: every request
+to Relay presents credentials in one of three forms (HMAC, Bearer
+api_key:api_secret, Bearer JWT) and ``authenticate_request`` resolves
+them into a single :class:`CallerContext`. CSSV1 R9.4 — pin the
+branching with synthetic Request objects so a regression in the
+header-shape detection (e.g., misclassifying a JWT as service creds)
+shows up loudly.
+
+Tests construct ``Request`` directly via Starlette's test scope shape
+rather than the full FastAPI test client; the dispatcher is a plain
+async function with no FastAPI runtime dependencies, and a synthetic
+scope is faster + isolates the branching from middleware ordering.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import AsyncMock
+
+import pytest
+from starlette.requests import Request
+
+from src.api.caller_context import CallerContext
+from src.api.deps import authenticate_request
+from src.config import RelayConfig
+from src.core.auth import compute_signature
+from src.errors import (
+    AuthenticationFailedError,
+    AuthUpstreamUnavailableError,
+    HeartBeatUnavailableError,
+    InvalidAPIKeyError,
+    JWTRejectedError,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_app_state(
+    *,
+    config: Optional[RelayConfig] = None,
+    api_key_secrets: Optional[Dict[str, str]] = None,
+    introspect_client: Any = None,
+    tenant_registry: Optional[Dict[str, Any]] = None,
+) -> SimpleNamespace:
+    """Minimal app.state stand-in covering every dispatcher dependency."""
+    return SimpleNamespace(
+        config=config or RelayConfig(
+            heartbeat_api_key="hb-key",
+            heartbeat_api_secret="hb-sec",
+        ),
+        api_key_secrets=api_key_secrets or {},
+        introspect_client=introspect_client,
+        tenant_registry=tenant_registry or {},
+    )
+
+
+def _make_request(
+    *,
+    headers: Dict[str, str],
+    raw_body: bytes = b"",
+    app_state: Optional[SimpleNamespace] = None,
+) -> Request:
+    """Build a Starlette ``Request`` with the given headers + cached body.
+
+    Mimics what ``BodyCacheMiddleware`` + ``TraceIDMiddleware`` write into
+    ``scope["state"]`` so the dispatcher can read the cached body via
+    ``request.state.raw_body``.
+    """
+    header_pairs: List[Tuple[bytes, bytes]] = [
+        (k.lower().encode("latin-1"), v.encode("latin-1"))
+        for k, v in headers.items()
+    ]
+    state: Dict[str, Any] = {"raw_body": raw_body, "trace_id": "test-trace"}
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/ingest",
+        "headers": header_pairs,
+        "query_string": b"",
+        "state": state,
+    }
+
+    # Attach an app stub so request.app.state.* works.
+    if app_state is None:
+        app_state = _make_app_state()
+    scope["app"] = SimpleNamespace(state=app_state)
+
+    async def _empty_receive() -> Dict[str, Any]:  # pragma: no cover
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(scope, receive=_empty_receive)
+
+
+# ── HMAC path (§3.3) ─────────────────────────────────────────────────────
+
+
+class TestDispatcherHmacPath:
+    """HMAC headers present → ``_verify_hmac`` → erp CallerContext."""
+
+    @pytest.mark.asyncio
+    async def test_valid_hmac_routes_to_erp(self):
+        api_key = "test-key-001"
+        secret = "secret-for-test-key-001"
+        body = b"some body"
+        # Use current time formatted for the existing window logic.
+        from datetime import datetime, timezone
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        sig = compute_signature(api_key, ts, body, secret)
+
+        app_state = _make_app_state(api_key_secrets={api_key: secret})
+        req = _make_request(
+            headers={
+                "X-API-Key": api_key,
+                "X-Timestamp": ts,
+                "X-Signature": sig,
+            },
+            raw_body=body,
+            app_state=app_state,
+        )
+
+        ctx = await authenticate_request(req)
+
+        assert isinstance(ctx, CallerContext)
+        assert ctx.actor_type == "erp"
+        assert ctx.identifier == api_key
+        assert ctx.raw_api_key == api_key
+        # Default ERP permissions baked into _verify_hmac
+        assert "blob.write" in ctx.permissions
+
+    @pytest.mark.asyncio
+    async def test_hmac_path_takes_precedence_over_bearer(self):
+        """If BOTH HMAC headers and Authorization: Bearer are present, HMAC wins.
+
+        Per the dispatcher's order-of-checks (HMAC first), the Authorization
+        header should be ignored — pinning this so a future refactor doesn't
+        accidentally invert the precedence.
+        """
+        api_key = "test-key-001"
+        secret = "secret-for-test-key-001"
+        body = b""
+        from datetime import datetime, timezone
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        sig = compute_signature(api_key, ts, body, secret)
+
+        # Bogus introspect client that would explode if the dispatcher
+        # mistakenly took the Bearer branch.
+        introspect = AsyncMock()
+        introspect.introspect.side_effect = AssertionError(
+            "dispatcher fell through to Bearer despite valid HMAC headers"
+        )
+
+        app_state = _make_app_state(
+            api_key_secrets={api_key: secret},
+            introspect_client=introspect,
+        )
+        req = _make_request(
+            headers={
+                "X-API-Key": api_key,
+                "X-Timestamp": ts,
+                "X-Signature": sig,
+                "Authorization": "Bearer some.jwt.value",
+            },
+            raw_body=body,
+            app_state=app_state,
+        )
+
+        ctx = await authenticate_request(req)
+        assert ctx.actor_type == "erp"
+        introspect.introspect.assert_not_called()
+
+
+# ── Service-creds path (§3.2) ────────────────────────────────────────────
+
+
+class TestDispatcherServiceCredsPath:
+    """``Bearer api_key:api_secret`` (single colon, no JWT dots) → service."""
+
+    @pytest.mark.asyncio
+    async def test_valid_service_creds_route(self):
+        api_key = "core-svc"
+        secret = "core-svc-secret"
+        app_state = _make_app_state(api_key_secrets={api_key: secret})
+        req = _make_request(
+            headers={"Authorization": f"Bearer {api_key}:{secret}"},
+            app_state=app_state,
+        )
+
+        ctx = await authenticate_request(req)
+
+        assert ctx.actor_type == "service"
+        assert ctx.identifier == api_key
+        # Service creds are platform-admin by convention.
+        assert "*" in ctx.permissions
+
+    @pytest.mark.asyncio
+    async def test_unknown_service_creds_rejected(self):
+        app_state = _make_app_state(api_key_secrets={})
+        req = _make_request(
+            headers={"Authorization": "Bearer ghost-key:ghost-secret"},
+            app_state=app_state,
+        )
+
+        with pytest.raises(InvalidAPIKeyError):
+            await authenticate_request(req)
+
+    @pytest.mark.asyncio
+    async def test_wrong_secret_rejected(self):
+        app_state = _make_app_state(api_key_secrets={"k": "real-secret"})
+        req = _make_request(
+            headers={"Authorization": "Bearer k:wrong-secret"},
+            app_state=app_state,
+        )
+
+        with pytest.raises(InvalidAPIKeyError):
+            await authenticate_request(req)
+
+
+# ── User JWT path (§3.1) ─────────────────────────────────────────────────
+
+
+class TestDispatcherUserJwtPath:
+    """``Bearer <jwt>`` (compact JWS — two dots, no colon) → introspect."""
+
+    @pytest.mark.asyncio
+    async def test_valid_jwt_routes_via_introspect(self):
+        # Realistic compact JWS shape: header.payload.signature
+        jwt = "eyJ0eXAi.eyJzdWIi.SIGNATURE"
+
+        introspect_result = SimpleNamespace(
+            active=True,
+            actor_type="user",
+            user_id="user-123",
+            role="creator",
+            permissions=["blob.write"],
+            tenant_id="tenant-abbey",
+            device_id="device-1",
+            last_auth_at=None,
+            expires_at=None,
+            session_expires_at=None,
+            step_up_satisfied=True,
+            error_code=None,
+            message=None,
+        )
+        introspect = AsyncMock()
+        introspect.introspect.return_value = introspect_result
+
+        app_state = _make_app_state(introspect_client=introspect)
+        req = _make_request(
+            headers={
+                "Authorization": f"Bearer {jwt}",
+                "X-Source-ID": "float-app-1",
+            },
+            app_state=app_state,
+        )
+
+        ctx = await authenticate_request(req)
+
+        assert ctx.actor_type == "user"
+        assert ctx.identifier == "user-123"
+        assert ctx.tenant_id == "tenant-abbey"
+        assert ctx.source_id == "float-app-1"
+        assert ctx.downstream_auth_header == f"Bearer {jwt}"
+
+        introspect.introspect.assert_called_once()
+        kwargs = introspect.introspect.call_args.kwargs
+        assert kwargs["jwt_token"] == jwt
+
+    @pytest.mark.asyncio
+    async def test_introspect_unreachable_fails_closed_502(self):
+        """HB introspect down → ``AuthUpstreamUnavailableError`` (502).
+
+        Per BACKEND_SERVICE_AUTH_AND_ABUSE_SPEC §2.4, the dispatcher must
+        NEVER permit a request when the auth upstream is unreachable —
+        cached claims are not allowed.
+        """
+        introspect = AsyncMock()
+        introspect.introspect.side_effect = HeartBeatUnavailableError(
+            "HeartBeat down for the count"
+        )
+
+        app_state = _make_app_state(introspect_client=introspect)
+        req = _make_request(
+            headers={"Authorization": "Bearer eyJ.eyJ.SIG"},
+            app_state=app_state,
+        )
+
+        with pytest.raises(AuthUpstreamUnavailableError):
+            await authenticate_request(req)
+
+    @pytest.mark.asyncio
+    async def test_jwt_rejected_propagates(self):
+        """Introspect-mapped JWTRejectedError bubbles through unchanged."""
+        introspect = AsyncMock()
+        introspect.introspect.side_effect = JWTRejectedError(
+            error_code="TOKEN_EXPIRED",
+            message="Token expired at 2026-04-01T00:00:00Z",
+            status_code=401,
+        )
+
+        app_state = _make_app_state(introspect_client=introspect)
+        req = _make_request(
+            headers={"Authorization": "Bearer eyJ.eyJ.SIG"},
+            app_state=app_state,
+        )
+
+        with pytest.raises(JWTRejectedError) as exc_info:
+            await authenticate_request(req)
+        assert exc_info.value.error_code == "TOKEN_EXPIRED"
+
+    @pytest.mark.asyncio
+    async def test_introspect_client_missing_502(self):
+        """If app.state.introspect_client is None → fail closed."""
+        app_state = _make_app_state(introspect_client=None)
+        req = _make_request(
+            headers={"Authorization": "Bearer eyJ.eyJ.SIG"},
+            app_state=app_state,
+        )
+
+        with pytest.raises(AuthUpstreamUnavailableError):
+            await authenticate_request(req)
+
+
+# ── Header-shape detection edges ─────────────────────────────────────────
+
+
+class TestDispatcherHeaderShapeBranching:
+    """Pin the JWT-vs-service-creds heuristic so future tweaks regress loudly."""
+
+    @pytest.mark.asyncio
+    async def test_no_credentials_rejected(self):
+        req = _make_request(headers={})
+        with pytest.raises(AuthenticationFailedError):
+            await authenticate_request(req)
+
+    @pytest.mark.asyncio
+    async def test_empty_bearer_rejected(self):
+        req = _make_request(headers={"Authorization": "Bearer "})
+        with pytest.raises(AuthenticationFailedError):
+            await authenticate_request(req)
+
+    @pytest.mark.asyncio
+    async def test_bearer_with_only_whitespace_rejected(self):
+        req = _make_request(headers={"Authorization": "Bearer    "})
+        with pytest.raises(AuthenticationFailedError):
+            await authenticate_request(req)
+
+    @pytest.mark.asyncio
+    async def test_partial_hmac_falls_through(self):
+        """If only some HMAC headers are set, dispatcher must NOT take the HMAC branch.
+
+        With X-API-Key but no X-Timestamp/X-Signature, the HMAC validator
+        would crash. The dispatcher must either route elsewhere or reject
+        cleanly. With no Authorization header either, it should reject.
+        """
+        req = _make_request(headers={"X-API-Key": "k"})
+        with pytest.raises(AuthenticationFailedError):
+            await authenticate_request(req)
+
+    @pytest.mark.asyncio
+    async def test_jwt_with_colon_in_payload_routes_correctly(self):
+        """A real JWS contains two dots; even if base64url payload includes :, the heuristic must detect dots-first.
+
+        The dispatcher checks ``"." in token`` to disambiguate from
+        ``api_key:api_secret``. Pin this so a future refactor doesn't
+        accidentally misclassify a real JWT as service creds.
+        """
+        jwt = "eyJraWQiOiJ4OnkifQ.eyJzdWIiOiJ1OnkifQ.SIG_PART"
+        # The dispatcher should see the two dots and route to JWT.
+        introspect = AsyncMock()
+        introspect.introspect.return_value = SimpleNamespace(
+            active=True,
+            actor_type="user",
+            user_id="u",
+            role=None,
+            permissions=[],
+            tenant_id="t",
+            device_id=None,
+            last_auth_at=None,
+            expires_at=None,
+            session_expires_at=None,
+            step_up_satisfied=None,
+            error_code=None,
+            message=None,
+        )
+        app_state = _make_app_state(introspect_client=introspect)
+        req = _make_request(
+            headers={"Authorization": f"Bearer {jwt}"},
+            app_state=app_state,
+        )
+
+        ctx = await authenticate_request(req)
+        assert ctx.actor_type == "user"
+        introspect.introspect.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_bearer_three_part_no_dots_rejected(self):
+        """Token like ``a:b:c`` (more than one colon, no dots) is neither JWT nor service creds.
+
+        Currently the dispatcher routes it to JWT (since ``"." in token``
+        is False, but also the colon-count check fails for service creds).
+        Pin observed behaviour so a refactor catches the change.
+        """
+        introspect = AsyncMock()
+        introspect.introspect.side_effect = JWTRejectedError(
+            error_code="TOKEN_INVALID",
+            message="Not a JWT",
+        )
+        app_state = _make_app_state(introspect_client=introspect)
+        req = _make_request(
+            headers={"Authorization": "Bearer a:b:c"},
+            app_state=app_state,
+        )
+
+        with pytest.raises(JWTRejectedError):
+            await authenticate_request(req)

--- a/services/relay/tests/clients/test_bearer_removed_alarm.py
+++ b/services/relay/tests/clients/test_bearer_removed_alarm.py
@@ -1,0 +1,238 @@
+"""
+CSSV1 R9.3 — alarm path when HeartBeat returns ``BEARER_S2S_REMOVED``.
+
+This is a regression detector. After the Phase 0 catchup
+(``helium-multitenant-demo#16``, merged 2026-05-09), no Relay→HB call
+should EVER ship the dead ``Authorization: Bearer api_key:api_secret``
+form. If a code path slips back, HB returns ``401`` with body
+``{"error_code": "BEARER_S2S_REMOVED"}``, and Relay must:
+
+1. Increment ``relay_bearer_removed_received_total{endpoint=<context>}``.
+2. Emit an ERROR-level log (not WARNING — this is alarm-grade).
+
+The 401 itself still raises :class:`JWTRejectedError`; the alarm is a
+side-channel signal so ops sees the offending callsite via
+``/metrics`` rather than buried in 401 spam.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import respx
+from httpx import Response
+
+from src.clients.heartbeat import HeartBeatClient
+from src.clients.introspect import IntrospectClient
+from src.errors import HeartBeatUnavailableError, JWTRejectedError
+from src.observability import counters
+
+
+HB_URL = "http://hb.test:9000"
+SIGNING_KEY = "0123456789abcdef" * 4
+
+
+@pytest.fixture(autouse=True)
+def _reset_counters():
+    counters.reset()
+    yield
+    counters.reset()
+
+
+# ── HeartBeatClient path ─────────────────────────────────────────────────
+
+
+@pytest.fixture
+def hb_client():
+    return HeartBeatClient(
+        heartbeat_api_url=HB_URL,
+        timeout=5.0,
+        max_attempts=1,
+        trace_id="test-trace",
+        service_api_key="test-api-key",
+        service_api_secret="test-secret",
+        service_signing_key=SIGNING_KEY,
+    )
+
+
+class TestHeartBeatBearerRemovedAlarm:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_401_with_bearer_removed_increments_counter(self, hb_client):
+        respx.post(f"{HB_URL}/api/dedup/check").mock(
+            return_value=Response(
+                401,
+                json={
+                    "error_code": "BEARER_S2S_REMOVED",
+                    "message": "Bearer api_key:api_secret no longer accepted; "
+                    "send HMAC headers per HMAC_S2S_MIGRATION_SPEC §2.",
+                },
+            )
+        )
+
+        with pytest.raises(JWTRejectedError):
+            await hb_client.check_duplicate("abc123")
+
+        # Counter incremented with endpoint label set to the context string
+        out = list(counters.get_all())
+        assert out == [
+            (
+                "relay_bearer_removed_received_total",
+                {"endpoint": "check_duplicate"},
+                1,
+            )
+        ]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_401_with_bearer_removed_logs_error(self, hb_client, caplog):
+        respx.post(f"{HB_URL}/api/limits/daily/check").mock(
+            return_value=Response(
+                401, json={"error_code": "BEARER_S2S_REMOVED"}
+            )
+        )
+
+        with caplog.at_level("ERROR", logger="src.clients.heartbeat"):
+            with pytest.raises(JWTRejectedError):
+                await hb_client.check_daily_limit("co-1", file_count=1)
+
+        assert any(
+            "BEARER_S2S_REMOVED" in rec.message and rec.levelname == "ERROR"
+            for rec in caplog.records
+        ), "expected an ERROR-level log mentioning BEARER_S2S_REMOVED"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_401_with_bearer_removed_still_raises_jwt_rejected(self, hb_client):
+        """The exception type is unchanged — alarm is a side-channel signal."""
+        respx.post(f"{HB_URL}/api/dedup/check").mock(
+            return_value=Response(
+                401, json={"error_code": "BEARER_S2S_REMOVED"}
+            )
+        )
+
+        with pytest.raises(JWTRejectedError) as exc_info:
+            await hb_client.check_duplicate("abc")
+        assert exc_info.value.status_code == 401
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_401_other_error_does_not_increment_counter(self, hb_client):
+        """A regular HMAC_TIMESTAMP_SKEW 401 must NOT trip the alarm."""
+        respx.post(f"{HB_URL}/api/dedup/check").mock(
+            return_value=Response(
+                401,
+                json={
+                    "error_code": "HMAC_TIMESTAMP_SKEW",
+                    "message": "Timestamp outside 300s window",
+                },
+            )
+        )
+
+        with pytest.raises(JWTRejectedError):
+            await hb_client.check_duplicate("abc")
+
+        assert list(counters.get_all()) == []
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_401_with_no_json_body_does_not_increment(self, hb_client):
+        """Plaintext 401 (e.g., from a proxy) is not a BEARER_S2S_REMOVED signal."""
+        respx.post(f"{HB_URL}/api/dedup/check").mock(
+            return_value=Response(401, text="Unauthorized")
+        )
+
+        with pytest.raises(JWTRejectedError):
+            await hb_client.check_duplicate("abc")
+
+        assert list(counters.get_all()) == []
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_multiple_endpoints_separate_counter_rows(self, hb_client):
+        """Each (endpoint label) value gets its own counter row."""
+        respx.post(f"{HB_URL}/api/dedup/check").mock(
+            return_value=Response(
+                401, json={"error_code": "BEARER_S2S_REMOVED"}
+            )
+        )
+        respx.post(f"{HB_URL}/api/limits/daily/check").mock(
+            return_value=Response(
+                401, json={"error_code": "BEARER_S2S_REMOVED"}
+            )
+        )
+
+        with pytest.raises(JWTRejectedError):
+            await hb_client.check_duplicate("abc")
+        with pytest.raises(JWTRejectedError):
+            await hb_client.check_daily_limit("co-1")
+        with pytest.raises(JWTRejectedError):
+            await hb_client.check_duplicate("def")
+
+        # Bucket the snapshot by labels for readability
+        rows = {
+            tuple(sorted(lbls.items())): value
+            for _, lbls, value in counters.get_all()
+        }
+        assert rows[(("endpoint", "check_duplicate"),)] == 2
+        assert rows[(("endpoint", "check_daily_limit"),)] == 1
+
+
+# ── IntrospectClient path ────────────────────────────────────────────────
+
+
+class TestIntrospectBearerRemovedAlarm:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_401_bearer_removed_increments_introspect_counter(self):
+        respx.post(f"{HB_URL}/api/auth/introspect").mock(
+            return_value=Response(
+                401, json={"error_code": "BEARER_S2S_REMOVED"}
+            )
+        )
+
+        client = IntrospectClient(
+            heartbeat_url=HB_URL,
+            service_api_key="api-key",
+            service_signing_key=SIGNING_KEY,
+            timeout_s=5.0,
+        )
+
+        with pytest.raises(HeartBeatUnavailableError):
+            await client.introspect("eyJ.eyJ.SIG", trace_id="t")
+        await client.close()
+
+        out = list(counters.get_all())
+        assert out == [
+            (
+                "relay_bearer_removed_received_total",
+                {"endpoint": "introspect"},
+                1,
+            )
+        ]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_401_other_error_does_not_increment_introspect_counter(self):
+        """HMAC skew 401 (genuine config error) must not trip the alarm."""
+        respx.post(f"{HB_URL}/api/auth/introspect").mock(
+            return_value=Response(
+                401, json={"error_code": "HMAC_TIMESTAMP_SKEW"}
+            )
+        )
+
+        client = IntrospectClient(
+            heartbeat_url=HB_URL,
+            service_api_key="api-key",
+            service_signing_key=SIGNING_KEY,
+            timeout_s=5.0,
+        )
+
+        with pytest.raises(HeartBeatUnavailableError):
+            await client.introspect("eyJ.eyJ.SIG")
+        await client.close()
+
+        assert list(counters.get_all()) == []

--- a/services/relay/tests/observability/test_counters.py
+++ b/services/relay/tests/observability/test_counters.py
@@ -1,0 +1,119 @@
+"""
+Tests for ``src.observability.counters`` (CSSV1 R9 — alarming-counter
+infrastructure for the ``/metrics`` route).
+
+Covers ``inc()`` / ``get_all()`` / ``reset()`` semantics, label
+normalisation (sorted-tuple keying so ``{a:1,b:2}`` and ``{b:2,a:1}``
+collapse to one counter), and the integration with the ``/metrics``
+exposition.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.observability import counters
+
+
+@pytest.fixture(autouse=True)
+def _reset_counters():
+    """Each test starts with a clean counter dict."""
+    counters.reset()
+    yield
+    counters.reset()
+
+
+class TestInc:
+    def test_inc_no_labels_starts_at_one(self):
+        counters.inc("test_counter")
+        out = list(counters.get_all())
+        assert out == [("test_counter", {}, 1)]
+
+    def test_inc_multiple_increments_to_n(self):
+        for _ in range(5):
+            counters.inc("test_counter")
+        out = list(counters.get_all())
+        assert out == [("test_counter", {}, 5)]
+
+    def test_inc_with_labels_keyed_by_label_combo(self):
+        counters.inc("ep", labels={"endpoint": "introspect"})
+        counters.inc("ep", labels={"endpoint": "introspect"})
+        counters.inc("ep", labels={"endpoint": "fetch_config"})
+
+        result = {(name, tuple(sorted(lbls.items()))): v for name, lbls, v in counters.get_all()}
+        assert result[("ep", (("endpoint", "introspect"),))] == 2
+        assert result[("ep", (("endpoint", "fetch_config"),))] == 1
+
+    def test_label_order_does_not_matter(self):
+        """``{a:1,b:2}`` and ``{b:2,a:1}`` must collapse to the same counter."""
+        counters.inc("c", labels={"a": "1", "b": "2"})
+        counters.inc("c", labels={"b": "2", "a": "1"})
+        out = list(counters.get_all())
+        assert len(out) == 1
+        _, _, value = out[0]
+        assert value == 2
+
+    def test_different_label_value_creates_new_counter(self):
+        counters.inc("c", labels={"endpoint": "a"})
+        counters.inc("c", labels={"endpoint": "b"})
+        out = list(counters.get_all())
+        assert len(out) == 2
+
+    def test_label_values_coerced_to_str(self):
+        counters.inc("c", labels={"code": 200})
+        out = list(counters.get_all())
+        assert out == [("c", {"code": "200"}, 1)]
+
+
+class TestGetAll:
+    def test_empty_returns_empty_iterable(self):
+        assert list(counters.get_all()) == []
+
+    def test_returns_snapshot_independent_of_internal_state(self):
+        """Mutating the dict mid-iteration must not crash callers."""
+        counters.inc("a")
+        snapshot = list(counters.get_all())
+        counters.inc("b")
+        # snapshot still references the original 1-tuple
+        assert snapshot == [("a", {}, 1)]
+
+    def test_labels_returned_as_dict_not_tuple(self):
+        counters.inc("c", labels={"k": "v"})
+        for _, lbls, _ in counters.get_all():
+            assert isinstance(lbls, dict)
+            assert lbls == {"k": "v"}
+
+
+class TestReset:
+    def test_reset_wipes_all(self):
+        counters.inc("a")
+        counters.inc("b", labels={"x": "y"})
+        counters.reset()
+        assert list(counters.get_all()) == []
+
+
+class TestCounterHelpRegistry:
+    """The pre-declared ``COUNTER_HELP`` shapes the ``/metrics`` exposition."""
+
+    def test_includes_bearer_removed(self):
+        assert "relay_bearer_removed_received_total" in counters.COUNTER_HELP
+
+    def test_includes_amqp_publish(self):
+        assert "relay_amqp_publish_total" in counters.COUNTER_HELP
+
+    def test_includes_lock_acquire(self):
+        assert "relay_lock_acquire_duration_seconds" in counters.COUNTER_HELP
+
+    def test_includes_status_orchestration(self):
+        assert "relay_status_orchestration_duration_seconds" in counters.COUNTER_HELP
+
+    def test_help_entries_are_2_tuples(self):
+        for name, entry in counters.COUNTER_HELP.items():
+            assert isinstance(entry, tuple) and len(entry) == 2, (
+                f"COUNTER_HELP[{name!r}] must be (help_text, type_str)"
+            )
+            help_text, type_str = entry
+            assert isinstance(help_text, str) and help_text
+            assert type_str in {"counter", "gauge", "histogram"}, (
+                f"unknown Prometheus type {type_str!r} for {name}"
+            )

--- a/services/relay/tests/observability/test_startup_checks.py
+++ b/services/relay/tests/observability/test_startup_checks.py
@@ -1,0 +1,209 @@
+"""
+Tests for ``src.observability.startup_checks`` (CSSV1 R9.1 + R9.2).
+
+R9.1 — ``validate_signing_key_shape`` must:
+- accept exactly 64 lowercase-hex chars
+- pass empty silently (degraded dev mode, WARNING-only)
+- reject everything else with :class:`ConfigError`
+
+R9.2 — ``check_clock_skew_against_heartbeat`` must:
+- return the absolute skew when both sides reply with parseable Date
+- raise :class:`ConfigError` when skew exceeds the bail threshold
+- return ``None`` (warn-and-continue) on HB unreachable / no Date /
+  unparseable Date
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+
+import pytest
+import respx
+from httpx import Response
+
+from src.errors import ConfigError
+from src.observability.startup_checks import (
+    check_clock_skew_against_heartbeat,
+    validate_signing_key_shape,
+)
+
+
+HB_URL = "http://hb.test:9000"
+
+
+# ── R9.1 — signing-key shape ─────────────────────────────────────────────
+
+
+class TestValidateSigningKeyShape:
+
+    def test_valid_64_lowercase_hex_passes(self):
+        # secrets.token_hex(32) shape — what HB actually generates
+        validate_signing_key_shape("0123456789abcdef" * 4)
+
+    def test_empty_string_passes_with_warning(self, caplog):
+        """Empty key is the degraded dev-mode signal — WARN, don't bail."""
+        with caplog.at_level("WARNING", logger="src.observability.startup_checks"):
+            validate_signing_key_shape("")
+        assert any(
+            "DEGRADED" in rec.message for rec in caplog.records
+        ), "expected a WARNING about degraded dev mode"
+
+    def test_uppercase_hex_rejected(self):
+        with pytest.raises(ConfigError):
+            validate_signing_key_shape("ABCDEF" + "0" * 58)
+
+    def test_short_key_rejected(self):
+        with pytest.raises(ConfigError):
+            validate_signing_key_shape("abc123")
+
+    def test_long_key_rejected(self):
+        with pytest.raises(ConfigError):
+            validate_signing_key_shape("0" * 65)
+
+    def test_non_hex_chars_rejected(self):
+        # 64 chars but contains 'g'
+        with pytest.raises(ConfigError):
+            validate_signing_key_shape("g" + "0" * 63)
+
+    def test_leading_whitespace_rejected(self):
+        with pytest.raises(ConfigError):
+            validate_signing_key_shape(" " + "0" * 64)
+
+    def test_prefix_rejected(self):
+        """``hex:0123…`` shape (an operator might paste with a prefix)."""
+        with pytest.raises(ConfigError):
+            validate_signing_key_shape("hex:" + "0" * 64)
+
+    def test_error_message_does_not_leak_key(self):
+        """ConfigError message must not include the bogus key value."""
+        bad = "supersecretvaluedontprintme" + "0" * 37
+        with pytest.raises(ConfigError) as exc_info:
+            validate_signing_key_shape(bad)
+        assert "supersecretvaluedontprintme" not in str(exc_info.value.message)
+
+
+# ── R9.2 — NTP discipline ────────────────────────────────────────────────
+
+
+def _date_header(dt: datetime) -> str:
+    """RFC 7231 Date format (e.g., 'Wed, 21 Oct 2026 07:28:00 GMT')."""
+    return format_datetime(dt, usegmt=True)
+
+
+class TestCheckClockSkewSuccess:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_in_sync_returns_small_skew(self):
+        now = datetime.now(timezone.utc)
+        respx.get(f"{HB_URL}/health").mock(
+            return_value=Response(200, headers={"Date": _date_header(now)})
+        )
+
+        skew = await check_clock_skew_against_heartbeat(HB_URL)
+
+        assert skew is not None
+        assert skew < 5.0  # well within the 60s threshold
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_skew_just_under_threshold_passes(self):
+        # 30 seconds off — under the 60s default
+        hb_time = datetime.now(timezone.utc) - timedelta(seconds=30)
+        respx.get(f"{HB_URL}/health").mock(
+            return_value=Response(200, headers={"Date": _date_header(hb_time)})
+        )
+
+        skew = await check_clock_skew_against_heartbeat(HB_URL)
+        assert skew is not None
+        assert 25 < skew < 35
+
+
+class TestCheckClockSkewBail:
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_skew_over_threshold_raises_config_error(self):
+        # 5 minutes off — way over the 60s default
+        hb_time = datetime.now(timezone.utc) - timedelta(seconds=300)
+        respx.get(f"{HB_URL}/health").mock(
+            return_value=Response(200, headers={"Date": _date_header(hb_time)})
+        )
+
+        with pytest.raises(ConfigError) as exc_info:
+            await check_clock_skew_against_heartbeat(HB_URL)
+        assert "Clock skew" in exc_info.value.message
+        assert "300" in exc_info.value.message or "299" in exc_info.value.message
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_future_skew_also_raises(self):
+        """Skew is symmetric — 90 s in the future is just as bad as 90 s in the past."""
+        hb_time = datetime.now(timezone.utc) + timedelta(seconds=90)
+        respx.get(f"{HB_URL}/health").mock(
+            return_value=Response(200, headers={"Date": _date_header(hb_time)})
+        )
+
+        with pytest.raises(ConfigError):
+            await check_clock_skew_against_heartbeat(HB_URL)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_custom_bail_threshold_respected(self):
+        hb_time = datetime.now(timezone.utc) - timedelta(seconds=20)
+        respx.get(f"{HB_URL}/health").mock(
+            return_value=Response(200, headers={"Date": _date_header(hb_time)})
+        )
+
+        # Tight 10s threshold — 20s skew should bail
+        with pytest.raises(ConfigError):
+            await check_clock_skew_against_heartbeat(
+                HB_URL, bail_threshold_s=10.0
+            )
+
+
+class TestCheckClockSkewSoftFail:
+    """When the check can't run, return None + log WARNING — never bail."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_hb_unreachable_returns_none(self):
+        respx.get(f"{HB_URL}/health").mock(
+            side_effect=__import__("httpx").ConnectError("nope")
+        )
+
+        skew = await check_clock_skew_against_heartbeat(HB_URL)
+        assert skew is None
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_missing_date_header_returns_none(self):
+        respx.get(f"{HB_URL}/health").mock(
+            return_value=Response(200, headers={})
+        )
+
+        skew = await check_clock_skew_against_heartbeat(HB_URL)
+        assert skew is None
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_unparseable_date_returns_none(self):
+        respx.get(f"{HB_URL}/health").mock(
+            return_value=Response(
+                200, headers={"Date": "not-a-date"}
+            )
+        )
+
+        skew = await check_clock_skew_against_heartbeat(HB_URL)
+        assert skew is None
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_timeout_returns_none(self):
+        respx.get(f"{HB_URL}/health").mock(
+            side_effect=__import__("httpx").TimeoutException("slow")
+        )
+
+        skew = await check_clock_skew_against_heartbeat(HB_URL)
+        assert skew is None


### PR DESCRIPTION
## Summary

First chip of CSSV1 **S1 — Defensive coding + audit baseline** per `helium-services` PR #107 (RELAY_DEV_HANDOFF_CSSV1_2026_05_10.md §S1). Implements R9 in full — four sub-items, all self-contained, no contract surface touches. Relay can deploy this independently while HB Drift D1 + schema-delta work continues in parallel.

- **R9.1** — Signing-key shape validation (64-lowercase-hex regex; ConfigError fail-fast on malformed key; WARN on empty for degraded dev mode; key value scrubbed from error message).
- **R9.2** — Best-effort NTP discipline check at startup (HB `/health` Date header vs local UTC; bail on >60s skew; soft-fail on unreachable HB so cold-start ordering doesn't deadlock).
- **R9.3** — `BEARER_S2S_REMOVED` alarm: in-memory Prometheus-style counter exposed via `/metrics`. `HeartBeatClient` + `IntrospectClient` increment `relay_bearer_removed_received_total{endpoint=<context>}` on the alarm 401, plus ERROR-level log. Side-channel signal so a regressed callsite surfaces in `/metrics` rather than buried in 401 spam.
- **R9.4** — Dispatcher coverage tests for `src/api/deps.authenticate_request`. Pins HMAC > Bearer-service-creds > Bearer-JWT precedence; partial-HMAC rejection; introspect-unreachable fail-closed (502); JWT-with-colon-in-payload routes correctly via dot-detection heuristic.

## Files changed (13)

**New (8):**
- `src/observability/__init__.py`
- `src/observability/counters.py` — pure-Python in-memory counter (no `prometheus_client` dep yet)
- `src/observability/startup_checks.py` — R9.1 + R9.2 helpers
- `tests/observability/__init__.py`
- `tests/observability/test_counters.py` (15 cases)
- `tests/observability/test_startup_checks.py` (18 cases)
- `tests/clients/test_bearer_removed_alarm.py` (8 cases)
- `tests/api/test_auth_dispatcher.py` (13 cases)

**Modified (5):**
- `src/errors.py` — add `ConfigError`
- `src/api/app.py` — call R9.1 + R9.2 from lifespan before constructing clients
- `src/api/routes/metrics.py` — render counters via `_emit_counters()`
- `src/clients/heartbeat.py` — `_check_bearer_removed_alarm()` in `_raise_for_status`
- `src/clients/introspect.py` — same alarm path on the introspect 401 branch

## Test plan

- [x] **Observability tests (33/33 pass)** — counter semantics, label normalisation, R9.1 shape validation, R9.2 NTP success/bail/soft-fail
- [x] **Bearer-removed alarm tests (8/8 pass)** — counter increment, ERROR log, `JWTRejectedError` still raised, non-alarm 401s do not increment, multiple endpoints get separate counter rows, introspect path mirrors HB path
- [x] **Dispatcher tests (15/15 pass)** — HMAC takes precedence over Bearer; service-creds rejection on bad secret; JWT routes via introspect; introspect down → 502; partial HMAC rejected; JWT-with-colon-in-payload disambiguated correctly
- [x] **Full Relay suite** — 528 passed, 7 failed. All 7 failures are pre-existing on `origin/main` (verified by `git stash` + rerun): module-cache mock setup mismatches in `test_irn`/`test_qr`/`test_external` + ingest-route 401-vs-422 expectation drift. **Not regressions from this chip.**
- [ ] **EC2 staging smoke test (post-merge)** — redeploy `relay-api`, hit `/metrics`, confirm `relay_bearer_removed_received_total` HELP+TYPE block present at zero samples; smoke-test a deliberate Bearer regression in a sandbox to confirm the counter increments

## Out of scope (next chips, sequenced)

- **R12 — Introspect cache** (S1 chip 2): 30s LRU keyed on `jti`, negative cache, `X-Bypass-Auth-Cache` header.
- **R11 — Idempotency middleware** (S1 chip 3): PG-backed 5-min TTL, replay returns original response.
- **R10 — Audit emission baseline + record_duplicate deletion + health/metrics review** (S1 chip 4): finishes S1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
