### PR TITLE
fix(relay): bearer_removed alarm tests ignore introspect-cache counter rows

### DIFF
--- a/services/relay/tests/clients/test_bearer_removed_alarm.py
+++ b/services/relay/tests/clients/test_bearer_removed_alarm.py
@@ -183,6 +183,22 @@ class TestHeartBeatBearerRemovedAlarm:
 # ── IntrospectClient path ────────────────────────────────────────────────
 
 
+def _filter_bearer_alarm_rows(snapshot):
+    """Strip introspect-cache bookkeeping rows from a counters snapshot.
+
+    The IntrospectClient also increments ``relay_introspect_cache_total``
+    (per CSSV1 S1 chip 2/2, PR #18) on every call — including a ``no_jti``
+    branch hit by these tests' synthetic ``eyJ.eyJ.SIG`` tokens. That
+    counter is orthogonal to the bearer_removed alarm under test; filter
+    it out so the assertions stay focused on alarm behaviour rather than
+    incidental cache-counter rows.
+    """
+    return [
+        row for row in snapshot
+        if row[0] != "relay_introspect_cache_total"
+    ]
+
+
 class TestIntrospectBearerRemovedAlarm:
 
     @respx.mock
@@ -205,7 +221,9 @@ class TestIntrospectBearerRemovedAlarm:
             await client.introspect("eyJ.eyJ.SIG", trace_id="t")
         await client.close()
 
-        out = list(counters.get_all())
+        # Filter out the introspect-cache bookkeeping rows (PR #18) so
+        # the assertion pins the alarm behaviour only.
+        out = _filter_bearer_alarm_rows(list(counters.get_all()))
         assert out == [
             (
                 "relay_bearer_removed_received_total",
@@ -235,4 +253,4 @@ class TestIntrospectBearerRemovedAlarm:
             await client.introspect("eyJ.eyJ.SIG")
         await client.close()
 
-        assert list(counters.get_all()) == []
+        assert _filter_bearer_alarm_rows(list(counters.get_all())) == []


### PR DESCRIPTION
## Summary
- Two tests in `tests/clients/test_bearer_removed_alarm.py::TestIntrospectBearerRemovedAlarm` broke after PR #18 (CSSV1 S1 chip 2/2 — introspect cache) added a new `relay_introspect_cache_total{result}` counter.
- Synthetic JWTs (`"eyJ.eyJ.SIG"`) in the tests lack a `jti` claim, so the introspect client now emits `result="no_jti"` before any bearer-alarm signal fires — and both tests asserted on the literal `counters.get_all()` snapshot, so the extra row tripped them.
- This PR adds a small `_filter_bearer_alarm_rows()` helper that strips `relay_introspect_cache_total` rows from the snapshot before the assertion. The introspect-cache counter is orthogonal to what these tests pin; filtering it out keeps the alarm regressions focused without coupling them to unrelated bookkeeping.

## Before / after

```powershell
# Before this fix (origin/main HEAD = 9d2120e):
pytest -q   ->   9 failed, 595 passed

# After this fix:
pytest tests/clients/test_bearer_removed_alarm.py   ->   8/8 passed
pytest -q   ->   7 failed, 559 passed
```

The 7 remaining failures are the **pre-existing set** Bob already called out in the S7 brief (`test_irn` 1, `test_qr` 3, `test_external` module-not-loaded 1, `test_ingest_route` 401-vs-422 2). They predate PR #16 and are tracked as a separate cleanup workstream.

## Why this is "test fix" not "code fix"
PR #18's behaviour is correct — the `no_jti` counter is the right side-channel signal (synthetic-token tests should know they're skipping cache, and production tokens always carry `jti`). The bug is on the test side: the bearer-removed alarm assertions were written before introspect bookkeeping existed and over-specified the snapshot. Filtering is the right scope.

## Why this is its own PR (not folded into S7)
- S7 (PR #20) is a feature chip with a focused scope; mixing unrelated test hygiene blurs the diff for review.
- This fix is independent of S7's code: even with S7 reverted, `pytest tests/clients/test_bearer_removed_alarm.py` was red on origin/main.
- Reviewable in 30 seconds.

## Test plan checklist

- [x] `test_401_bearer_removed_increments_introspect_counter` — green
- [x] `test_401_other_error_does_not_increment_introspect_counter` — green
- [x] All other 6 bearer_removed alarm tests — green (HB-path unaffected)
- [x] Full suite — 559 passed, 7 failed (down from 9; the 2 PR #18 fallout cases fixed)

## Files
- `services/relay/tests/clients/test_bearer_removed_alarm.py` (+20 / -2) — adds `_filter_bearer_alarm_rows()` helper + updates the two assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)