### PR TITLE
feat(relay): CSSV1 S4a - R7 helium-hash adoption + record_duplicate deletion

### DIFF
--- a/services/relay/Dockerfile
+++ b/services/relay/Dockerfile
@@ -6,6 +6,13 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Vendored cross-repo packages (CSSV1 D8 helium_hash — canonical SHA-256
+# primitives shared across HB / Relay / Float SDK / Reader-Scout SDK).
+# Mirrored from helium-services-phase3/packages/helium-hash/. See
+# `vendor/README.md` for the update protocol.
+COPY vendor/ vendor/
+ENV PYTHONPATH=/app/vendor
+
 # Copy source
 COPY src/ src/
 

--- a/services/relay/pytest.ini
+++ b/services/relay/pytest.ini
@@ -8,6 +8,11 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 
+# Python path — make vendored packages (CSSV1 D8 helium_hash) resolvable
+# via the canonical `from helium_hash import ...` import path. See
+# `vendor/README.md`.
+pythonpath = . vendor
+
 # Async mode
 asyncio_mode = auto
 

--- a/services/relay/src/clients/heartbeat.py
+++ b/services/relay/src/clients/heartbeat.py
@@ -27,8 +27,8 @@ Auth model (post-HMAC-cutover 2026-05-09 per HMAC_S2S_MIGRATION_SPEC.md
       §4.2 ("wire your audit emission via the same helper now so you
       get auth-enabled-for-free later" once D-audit fix lands). HB
       currently ignores the headers; harmless.
-    - Metrics report, dedup record: No auth (not in §1.5 migration list).
-      Follow-up chip if HB tightens auth on these endpoints.
+    - Metrics report: No auth (not in §1.5 migration list).
+      Follow-up chip if HB tightens auth on this endpoint.
     - Health: No auth.
 
 Audit logging and metrics are fire-and-forget: failures are logged
@@ -81,7 +81,8 @@ class HeartBeatClient(BaseClient):
 
         # Deduplication
         POST /api/dedup/check        → Check for duplicate hash
-        POST /api/dedup/record       → Record processed hash
+        # (record_duplicate removed in CSSV1 S4 R7 — HB writes the
+        #  blob.blob_deduplication row as a side effect of /api/blobs/register)
 
         # Limits
         POST /api/limits/daily/check → Check daily usage limit
@@ -398,44 +399,15 @@ class HeartBeatClient(BaseClient):
 
         return await self.call_with_retries(_check)
 
-    async def record_duplicate(
-        self,
-        file_hash: str,
-        queue_id: str,
-    ) -> Dict[str, Any]:
-        """
-        Record a file hash after successful processing.
-
-        POST /api/dedup/record  JSON: {file_hash, queue_id}
-
-        Args:
-            file_hash: SHA256 hex digest.
-            queue_id: Queue ID the file was processed under.
-
-        Returns:
-            {file_hash, queue_id, status}
-        """
-        async def _record():
-            http = self._get_http()
-            headers = self.get_trace_headers()
-
-            self._calls.append(("record_duplicate", file_hash, queue_id))
-
-            try:
-                resp = await http.post(
-                    "/api/dedup/record",
-                    json={"file_hash": file_hash, "queue_id": queue_id},
-                    headers=headers,
-                )
-            except httpx.ConnectError as e:
-                raise HeartBeatUnavailableError(
-                    message=f"Cannot connect to HeartBeat for dedup record: {e}"
-                ) from e
-
-            self._raise_for_status(resp, "record_duplicate")
-            return resp.json()
-
-        return await self.call_with_retries(_record)
+    # ── (CSSV1 S4 R7) ``record_duplicate()`` removed ───────────────────────
+    #
+    # The legacy ``POST /api/dedup/record`` call was deleted in CSSV1 S4.
+    # HB now writes the canonical ``blob.blob_deduplication`` row as a
+    # side effect of the ``POST /api/blobs/register`` handler (D2) — there
+    # is no separate "record" hop from Relay. If you're tempted to add
+    # one back, the right answer is "HB's register handler should be the
+    # source of truth"; surface the gap as an HB chip, not a Relay
+    # workaround.
 
     # ── Daily Limits ───────────────────────────────────────────────────────
 

--- a/services/relay/src/core/dedup.py
+++ b/services/relay/src/core/dedup.py
@@ -9,12 +9,19 @@ Level 2: HeartBeat persistent check (across all uploads, all tenants).
 
 Graceful degradation: If HeartBeat is unavailable, allow the upload
 and log a warning. Session cache still catches within-batch duplicates.
+
+Hash algorithm: SHA-256 via the canonical ``helium_hash`` library
+(CSSV1 D8 / S4 R7 — `HASHING_CONTRACT.md`). Same primitive shipped to
+HB, Float SDK, and Reader/Scout SDK so the four consumers agree
+byte-for-byte. Do NOT call ``hashlib.sha256`` directly here — that
+would diverge from the canonical 64 KiB chunk + lowercase-hex contract.
 """
 
-import hashlib
 import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Set, Tuple
+
+from helium_hash import sha256_file
 
 logger = logging.getLogger(__name__)
 
@@ -57,8 +64,10 @@ class DedupChecker:
 
     @staticmethod
     def compute_hash(file_data: bytes) -> str:
-        """Compute SHA256 hex digest of file data."""
-        return hashlib.sha256(file_data).hexdigest()
+        """Compute SHA-256 hex digest of file data via the canonical
+        ``helium_hash`` library (CSSV1 D8). Lowercase 64-char hex.
+        """
+        return sha256_file(file_data)
 
     async def check(self, file_data: bytes) -> DedupResult:
         """

--- a/services/relay/src/services/ingestion.py
+++ b/services/relay/src/services/ingestion.py
@@ -26,11 +26,11 @@ Identity model:
                        Forwarded to HeartBeat as blob_batches.batch_display_id.
 """
 
-import hashlib
 import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
+from helium_hash import sha256_file
 from uuid6 import uuid7
 
 from ..config import RelayConfig
@@ -146,7 +146,9 @@ class IngestionService:
         per_file_hashes: List[str] = []
 
         for filename, file_data in files:
-            file_hash = hashlib.sha256(file_data).hexdigest()
+            # CSSV1 S4 (R7): canonical SHA-256 via helium_hash. Same
+            # primitive as HB / Float SDK / Reader/Scout SDK.
+            file_hash = sha256_file(file_data)
             per_file_hashes.append(file_hash)
 
             dedup_result = await dedup.check(file_data)
@@ -219,25 +221,20 @@ class IngestionService:
             f"{len(files)} files, data_uuid={data_uuid}"
         )
 
-        # Record dedup hashes after successful commit
-        # Level 1: Session cache (in-memory, per-request)
+        # Record dedup hashes after successful commit (session cache only).
+        #
+        # CSSV1 S4 (R7): the Level-2 HeartBeat persistent record path was
+        # deleted in this chip. Authoritative dedup state now flows
+        # through HB's own /api/blobs/register handler (D2) which writes
+        # `blob.blob_deduplication` rows as a side effect of the blob
+        # commit at Step 4. Relay no longer makes a separate
+        # /api/dedup/record call — that was an outbound chip from the
+        # pre-CSSV1 design and is now redundant.
+        #
+        # Session cache (Level 1) stays — it catches in-request
+        # duplicates without an HB round-trip per file.
         for file_hash in per_file_hashes:
             dedup.record(file_hash)
-
-        # Level 2: HeartBeat persistent record (across requests)
-        for file_hash in per_file_hashes:
-            try:
-                await self._heartbeat.record_duplicate(
-                    file_hash=file_hash,
-                    queue_id=data_uuid,
-                )
-            except Exception as e:
-                # Graceful degradation: if HeartBeat record fails,
-                # session cache still catches within-batch duplicates
-                logger.warning(
-                    f"[{trace_id}] HeartBeat dedup record failed "
-                    f"(hash={file_hash[:12]}...): {e}"
-                )
 
         # ── Step 5: Enqueue Core (best-effort) ────────────────────────────
         queue_id = await self._enqueue_core(

--- a/services/relay/tests/clients/test_heartbeat.py
+++ b/services/relay/tests/clients/test_heartbeat.py
@@ -261,27 +261,12 @@ class TestHeartBeatCheckDuplicate:
             await hb_client.check_duplicate("hash123")
 
 
-# ── Record Duplicate Tests ───────────────────────────────────────────────
-
-
-class TestHeartBeatRecordDuplicate:
-    """Test record_duplicate method — POST /api/dedup/record."""
-
-    @respx.mock
-    @pytest.mark.asyncio
-    async def test_record_success(self, hb_client):
-        respx.post(f"{HEARTBEAT_URL}/api/dedup/record").mock(
-            return_value=Response(201, json={
-                "file_hash": "hash-abc",
-                "queue_id": "queue-001",
-                "status": "recorded",
-            })
-        )
-
-        result = await hb_client.record_duplicate("hash-abc", "queue-001")
-        assert result["file_hash"] == "hash-abc"
-        assert result["queue_id"] == "queue-001"
-        assert result["status"] == "recorded"
+# ── Record Duplicate Tests (REMOVED — CSSV1 S4 R7) ───────────────────────
+#
+# The legacy ``record_duplicate()`` method was deleted in CSSV1 S4.
+# HB now writes ``blob.blob_deduplication`` rows as a side effect of
+# ``/api/blobs/register`` (D2). The standalone `POST /api/dedup/record`
+# endpoint is no longer called from Relay.
 
 
 # ── Daily Limit Tests ────────────────────────────────────────────────────

--- a/services/relay/tests/stub_heartbeat.py
+++ b/services/relay/tests/stub_heartbeat.py
@@ -44,9 +44,8 @@ class StubHeartBeatClient(HeartBeatClient):
             "original_queue_id": None,
         }
 
-    async def record_duplicate(self, file_hash, queue_id):
-        self._calls.append(("record_duplicate", file_hash, queue_id))
-        return {"file_hash": file_hash, "queue_id": queue_id, "status": "recorded"}
+    # CSSV1 S4 R7: record_duplicate() removed — HB writes
+    # blob.blob_deduplication as a side effect of /api/blobs/register.
 
     async def check_daily_limit(self, company_id, file_count=1):
         self._calls.append(("check_daily_limit", company_id, file_count))

--- a/services/relay/tests/test_vendored_helium_hash.py
+++ b/services/relay/tests/test_vendored_helium_hash.py
@@ -1,0 +1,115 @@
+"""
+Sanity tests for the vendored ``helium_hash`` package — CSSV1 S4 R7.
+
+Two purposes:
+    1. Confirm the canonical ``from helium_hash import ...`` import path
+       resolves (i.e., pytest's ``pythonpath = vendor`` and Docker's
+       ``ENV PYTHONPATH=/app/vendor`` are wired correctly).
+    2. Spot-check the §3 mandatory test vectors from
+       ``HASHING_CONTRACT.md`` so if the vendor copy drifts from the
+       source-of-truth package, the build goes red loudly.
+
+The helium-hash package has its own 75-test suite at
+``helium-services-phase3/packages/helium-hash/tests/`` with 100%
+line + branch coverage. THIS file is intentionally lightweight — just
+enough to detect "Relay imports a broken vendor copy" without
+duplicating the upstream tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from helium_hash import (
+    EmptyBatchError,
+    InvalidHashFormat,
+    sha256_batch,
+    sha256_file,
+    sha256_stream,
+)
+
+
+class TestVendoredImport:
+    """Verify the package resolves via the canonical import path."""
+
+    def test_module_resolves(self):
+        import helium_hash
+        assert hasattr(helium_hash, "sha256_file")
+        assert hasattr(helium_hash, "sha256_batch")
+        assert hasattr(helium_hash, "sha256_hlx")
+        assert hasattr(helium_hash, "sha256_stream")
+
+    def test_version_pinned(self):
+        import helium_hash
+        # Pinned at vendor time. Bump in lockstep with the source repo.
+        assert helium_hash.__version__ == "1.0.0"
+
+
+class TestSha256FileVectors:
+    """A handful of canonical vectors from HASHING_CONTRACT.md §3.
+    If these go red, the vendor copy is broken or the spec changed."""
+
+    def test_empty_bytes(self):
+        # SHA-256("") — the most boring known vector.
+        assert sha256_file(b"") == (
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        )
+
+    def test_ascii_test(self):
+        # SHA-256("test") — widely known regression test value.
+        assert sha256_file(b"test") == (
+            "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+        )
+
+    def test_chunked_path_matches_bytes_path(self, tmp_path):
+        """64 KiB chunked file reader must produce the same digest as
+        the bytes-direct path. Covers the contract's `_DEFAULT_CHUNK`
+        constant — if it ever drifts from 65536, this would catch it."""
+        payload = b"a" * (65537 * 2)  # crosses two full chunks + a remainder
+        p = tmp_path / "blob.bin"
+        p.write_bytes(payload)
+
+        assert sha256_file(p) == sha256_file(payload)
+
+
+class TestSha256BatchVectors:
+    """Spot-check the batch-hash composition."""
+
+    def test_single_file_batch(self):
+        # batch(sorted([H1])) — must equal SHA-256(H1) since concat == H1.
+        h1 = "a" * 64
+        import hashlib
+        expected = hashlib.sha256(h1.encode("ascii")).hexdigest()
+        assert sha256_batch([h1]) == expected
+
+    def test_sort_order_independence(self):
+        """The contract locks lex-sort before concat, so input order
+        must not affect the result."""
+        h1 = "a" * 64
+        h2 = "b" * 64
+        h3 = "c" * 64
+        assert sha256_batch([h1, h2, h3]) == sha256_batch([h3, h2, h1])
+        assert sha256_batch([h2, h1, h3]) == sha256_batch([h1, h2, h3])
+
+    def test_empty_batch_raises(self):
+        with pytest.raises(EmptyBatchError):
+            sha256_batch([])
+
+    def test_uppercase_hash_raises(self):
+        # Contract is lowercase-only.
+        with pytest.raises(InvalidHashFormat):
+            sha256_batch(["A" * 64])
+
+    def test_short_hash_raises(self):
+        with pytest.raises(InvalidHashFormat):
+            sha256_batch(["abc"])
+
+
+class TestSha256StreamVectors:
+    """Stream-based hashing path."""
+
+    def test_stream_matches_bytes(self):
+        import io
+        payload = b"streaming test payload" * 100
+        stream = io.BytesIO(payload)
+        assert sha256_stream(stream) == sha256_file(payload)

--- a/services/relay/vendor/README.md
+++ b/services/relay/vendor/README.md
@@ -1,0 +1,46 @@
+# Vendored Packages
+
+This directory holds third-party / cross-repo Python packages that Relay
+ships with at build time, per CSSV1 §3 D8 ("vendored into ... Relay
+container ... at build time").
+
+## helium_hash
+
+**Source of truth:** `helium-services-phase3/packages/helium-hash/src/helium_hash/`
+
+**Spec:** `helium-services-phase3/HeartBeat/Documentation/HASHING_CONTRACT.md`
+
+**Why vendored, not pip-installed:**
+- `helium-hash` is not (yet) published to PyPI — it's a path-only package
+  shared across four consumers (Float SDK, Reader/Scout SDK, Relay, HB).
+- Vendoring keeps the Relay container self-contained for Docker build.
+- The CSSV1 chip status doc (`CSSV1_CHIP_STATUS.md` §0) explicitly
+  contemplates this: "vendored into Relay container at build time."
+
+**Version pin:** v1.0.0 (from `helium-services-phase3@6665d39`, PR #113).
+
+**How `from helium_hash import ...` resolves:**
+- `services/relay/pytest.ini` has `pythonpath = vendor` so pytest adds
+  this directory to `sys.path`.
+- `services/relay/Dockerfile` does `COPY vendor/ vendor/` and sets
+  `ENV PYTHONPATH=/app/vendor` so the runtime container resolves
+  imports the same way.
+
+## Updating
+
+To re-sync after a helium-hash bump in the source repo:
+
+```powershell
+$src = "C:\Users\PROBOOK\helium-services-phase3\packages\helium-hash\src\helium_hash"
+$dst = "C:\Users\PROBOOK\helium-multitenant-demo\services\relay\vendor\helium_hash"
+Copy-Item "$src\*" $dst -Force
+```
+
+Then re-run `pytest tests/` to confirm vectors still pass.
+
+## What MUST NOT be vendored here
+
+- Anything Relay-internal — that goes in `src/`.
+- Anything published to PyPI — that goes in `requirements.txt`.
+- Anything specific to a single deploy environment — that's container
+  config (env vars + volumes).

--- a/services/relay/vendor/helium_hash/__init__.py
+++ b/services/relay/vendor/helium_hash/__init__.py
@@ -1,0 +1,27 @@
+"""Canonical SHA-256 hashing primitives for the Helium platform.
+
+Spec: HeartBeat/Documentation/HASHING_CONTRACT.md
+"""
+
+from helium_hash.algorithms import (
+    sha256_batch,
+    sha256_file,
+    sha256_hlx,
+    sha256_stream,
+)
+from helium_hash.errors import (
+    EmptyBatchError,
+    HashError,
+    InvalidHashFormat,
+)
+
+__all__ = [
+    "sha256_file",
+    "sha256_batch",
+    "sha256_hlx",
+    "sha256_stream",
+    "HashError",
+    "InvalidHashFormat",
+    "EmptyBatchError",
+]
+__version__ = "1.0.0"

--- a/services/relay/vendor/helium_hash/algorithms.py
+++ b/services/relay/vendor/helium_hash/algorithms.py
@@ -1,0 +1,80 @@
+"""SHA-256 primitives per HASHING_CONTRACT.md §1 + §4.
+
+Algorithm parameters are bit-locked: changing them is a major-version bump
+that forces re-hashing the entire blob store.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import BinaryIO, Union
+
+from helium_hash.errors import EmptyBatchError, InvalidHashFormat
+
+_HEX64_CHARS = frozenset("0123456789abcdef")
+_DEFAULT_CHUNK = 65536  # 64 KiB — matches legacy Float upload_manager.py:1282
+
+FileSource = Union[str, "os.PathLike[str]", bytes, bytearray]
+
+
+def _is_hex64_lower(s: str) -> bool:
+    if len(s) != 64:
+        return False
+    return all(c in _HEX64_CHARS for c in s)
+
+
+def sha256_file(source: FileSource) -> str:
+    """SHA-256 of body bytes. Returns 64-char lowercase hex.
+
+    Filename is not part of the digest — rename-safe.
+    Paths read in 64 KiB chunks; bytes-like inputs hash directly.
+    """
+    h = hashlib.sha256()
+    if isinstance(source, (bytes, bytearray)):
+        h.update(source)
+    else:
+        with open(source, "rb") as f:
+            while chunk := f.read(_DEFAULT_CHUNK):
+                h.update(chunk)
+    return h.hexdigest()
+
+
+def sha256_stream(stream: BinaryIO, chunk_size: int = _DEFAULT_CHUNK) -> str:
+    """Hash an open binary stream. Caller owns the stream lifecycle.
+
+    Use when a file handle already exists (e.g. multipart parsers) and you
+    don't want to re-open the underlying file.
+    """
+    h = hashlib.sha256()
+    while chunk := stream.read(chunk_size):
+        h.update(chunk)
+    return h.hexdigest()
+
+
+def sha256_batch(file_hashes: list[str]) -> str:
+    """Sort lex, concat as ASCII bytes (no separator), SHA-256 the result.
+
+    Raises EmptyBatchError on empty input, InvalidHashFormat on any non-conforming entry.
+    """
+    if not file_hashes:
+        raise EmptyBatchError("sha256_batch requires at least one file hash")
+    for fh in file_hashes:
+        if not isinstance(fh, str) or not _is_hex64_lower(fh):
+            raise InvalidHashFormat(
+                f"expected 64-char lowercase hex, got {fh!r}"
+            )
+    sorted_hashes = sorted(file_hashes)
+    concat_bytes = "".join(sorted_hashes).encode("ascii")
+    return hashlib.sha256(concat_bytes).hexdigest()
+
+
+def sha256_hlx(canonical_bytes: bytes) -> str:
+    """SHA-256 of canonical-serialised HLX bytes.
+
+    NOTE: HLX canonical-form definition is OPEN — owned by the Reader team.
+    Until HLX_CANONICAL_FORM.md is published, callers MUST NOT compute or
+    compare HLX hashes for semantically-meaningful equivalence — risk of
+    divergent canonicalization producing different hashes for the same HLX.
+    """
+    return hashlib.sha256(canonical_bytes).hexdigest()

--- a/services/relay/vendor/helium_hash/errors.py
+++ b/services/relay/vendor/helium_hash/errors.py
@@ -1,0 +1,15 @@
+"""Exception hierarchy for helium_hash. See HASHING_CONTRACT.md §2.2."""
+
+from __future__ import annotations
+
+
+class HashError(Exception):
+    """Base for all helium_hash errors."""
+
+
+class InvalidHashFormat(HashError, ValueError):
+    """Hash string doesn't match expected lowercase-hex-64 shape."""
+
+
+class EmptyBatchError(HashError, ValueError):
+    """sha256_batch called with no inputs."""

--- a/services/relay/vendor/helium_hash/types.py
+++ b/services/relay/vendor/helium_hash/types.py
@@ -1,0 +1,35 @@
+"""Pydantic-compatible type aliases for hash strings. See HASHING_CONTRACT.md §2.1.
+
+This module imports pydantic lazily so callers without pydantic installed
+can still use the algorithm primitives. Install with `helium-hash[pydantic]`
+to get the Sha256Hex Annotated type.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+try:
+    from pydantic import StringConstraints
+except ImportError as exc:  # pragma: no cover - exercised only without extra
+    raise ImportError(
+        "Sha256Hex requires pydantic. Install with: pip install helium-hash[pydantic]"
+    ) from exc
+
+
+Sha256Hex = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^[0-9a-f]{64}$",
+        min_length=64,
+        max_length=64,
+    ),
+]
+"""A 64-character lowercase hex SHA-256 digest.
+
+Use in Pydantic models that pass hashes (e.g. ArtifactManifestRequest)
+so uppercase / wrong-length / non-hex strings fail validation at the API
+boundary rather than in handler code.
+"""
+
+__all__ = ["Sha256Hex"]


### PR DESCRIPTION
## CSSV1 S4a — R7 helium-hash adoption + record_duplicate deletion

Split from #22 (S4) per ARCH **option (b)** (REGISTRATION-ACK 2026-06-12): the clean two-thirds of S4 land now; the **R12 signed webhook stays FROZEN on ledger L5** (Ed25519 #68 vs symmetric 2-header harmonization), preserved in commit `7a661cb` on the #22 branch — un-freeze by rebuilding once L5 resolves.

Based on `main@889bfa7` (post-#21). The split is a **file-level partition** of `7a661cb` — no hunk surgery; the 5 R12-only files (`src/api/webhook_auth.py`, `tests/api/test_webhook_auth.py`, `src/api/routes/internal.py` wiring, `src/config.py` webhook_* fields, `src/errors.py` `WebhookAuthError`) are excluded and verified byte-identical to main.

### R7 — Hash library adoption
- Vendor `helium_hash` v1.0.0 → `services/relay/vendor/helium_hash/`, imported via the canonical `from helium_hash import sha256_file` (matches HB / Float SDK / Reader+Scout — the four consumers per `HASHING_CONTRACT.md`).
- `pytest.ini` `pythonpath = . vendor`; `Dockerfile` `COPY vendor/` + `ENV PYTHONPATH=/app/vendor`.
- SHA-256 call-sites swapped: `src/core/dedup.py`, `src/services/ingestion.py`. HMAC primitives (`_s2s_hmac.py`, `core/auth.py`, `core/qr.py`) intentionally **not** changed (different spec).

### record_duplicate() deletion
- HB now writes `blob.blob_deduplication` as a side effect of `POST /api/blobs/register` (D2); Relay's separate `POST /api/dedup/record` was redundant. Dropped `HeartBeatClient.record_duplicate()`, the `ingestion.py` post-commit loop, the stub, and the test class. Session-cache (Level 1) dedup stays.

### Tests
`python -m pytest tests/test_vendored_helium_hash.py tests/core/test_dedup.py tests/services/test_ingestion.py tests/clients/test_heartbeat.py` → **112 passed** (11 + 17 + 47 + 37) in 46s. The 7 pre-existing failures named in the S7 brief (test_irn, test_qr ×3, test_external module-not-loaded, test_ingest_route ×2) are untouched by this PR and out of scope.

### Refs
- ARCH ACK + option (b): `STATUS_ARCH.md` (RR channel), 2026-06-12.
- Frozen R12 record: `7a661cb` on `feat/relay-cssv1-s4-hash-lib-record-duplicate-webhook` (#22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
