### PR TITLE
feat(relay): R-M2 B-Submit — metadata.finalize + POST /api/finalize + relay.finalize.accepted

### DIFF
--- a/services/relay/src/api/app.py
+++ b/services/relay/src/api/app.py
@@ -32,8 +32,11 @@ from ..observability.startup_checks import (
 )
 from ..services.bulk import BulkService
 from ..services.external import ExternalService
+from ..services.finalize import FinalizeService
 from ..services.ingestion import IngestionService
+from ..services.lifecycle import CoreLifecyclePublisher
 from .middleware import BodyCacheMiddleware, TraceIDMiddleware, relay_error_handler
+from .routes.finalize import router as finalize_router
 from .routes.health import router as health_router
 from .routes.ingest import router as ingest_router
 from .routes.internal import router as internal_router
@@ -158,6 +161,12 @@ def create_app(
         bulk_service = BulkService(ingestion, core)
         external_service = ExternalService(ingestion, core, irn_gen, qr_gen)
 
+        # Lifecycle publisher seam (§B-EventLog) — default sink forwards
+        # relay.* events to Core over HTTP (discretionary ARCH ruling (c);
+        # AMQP-first deferred to S3). Swappable via app.state.lifecycle_publisher.
+        lifecycle_publisher = CoreLifecyclePublisher(core)
+        finalize_service = FinalizeService(core, lifecycle_publisher)
+
         # Store in app state
         app.state.config = config
         app.state.api_key_secrets = api_key_secrets
@@ -171,6 +180,8 @@ def create_app(
         app.state.ingestion = ingestion
         app.state.bulk_service = bulk_service
         app.state.external_service = external_service
+        app.state.lifecycle_publisher = lifecycle_publisher
+        app.state.finalize_service = finalize_service
 
         # Envelope placeholder (NaCl encryption configured later)
         app.state.envelope = None
@@ -205,6 +216,7 @@ def create_app(
     app.include_router(health_router)
     app.include_router(metrics_router)
     app.include_router(ingest_router)
+    app.include_router(finalize_router)
     app.include_router(internal_router)
 
     return app

--- a/services/relay/src/api/models.py
+++ b/services/relay/src/api/models.py
@@ -57,6 +57,49 @@ class IngestResponse(BaseModel):
     )
 
 
+# ── Finalize (#3 reference-only call) ────────────────────────────────────
+
+
+class FinalizeRequest(BaseModel):
+    """Request body for POST /api/finalize — the #3 reference-only call.
+
+    Reference-only: fiscalizes an ALREADY-ingested doc by reference. NO PDF
+    bytes (§B-Submit). At least one of ``ref`` / ``trace_id`` must be present.
+
+        ref       — file SHA-256 / doc_ref (the backend already holds the bytes)
+        trace_id  — Scout UUIDv7; carried across the #2↔#3 switch (§3.3), echoed
+                    on the resulting lifecycle SSE
+        doc_ref   — optional explicit doc_ref (defaults to ``ref``)
+    """
+
+    ref: str = Field(default="", description="File SHA-256 / doc_ref of an already-ingested doc")
+    trace_id: str = Field(default="", description="Scout UUIDv7 — echoed on the lifecycle SSE")
+    doc_ref: str = Field(default="", description="Optional explicit doc_ref (defaults to ref)")
+
+
+class FinalizeResponse(BaseModel):
+    """Response from POST /api/finalize (HTTP 202 accepted).
+
+    ``raw_bytes_sent`` is always False — the #3 call carries no bytes. A
+    duplicate / already-finalized ``trace_id`` does NOT reach this shape; it
+    returns 409 ALREADY_FINALIZED (client treats as success).
+    """
+
+    status: str = Field(default="accepted", description="accepted")
+    call: str = Field(default="finalize", description="Always 'finalize'")
+    finalize_by_reference: bool = Field(default=True)
+    raw_bytes_sent: bool = Field(default=False)
+    ref: str = Field(default="", description="Echoed reference")
+    doc_ref: str = Field(default="", description="Resolved doc_ref")
+    trace_id: str = Field(default="", description="Echoed trace_id")
+    event_id: str = Field(default="", description="Lifecycle event id")
+    event_family: str = Field(default="", description="Lifecycle event family (relay.finalize.accepted)")
+    idempotent_replay: bool = Field(
+        default=False,
+        description="True if this was an idempotent replay of a prior finalize",
+    )
+
+
 # ── Error Response ───────────────────────────────────────────────────────
 
 

--- a/services/relay/src/api/routes/finalize.py
+++ b/services/relay/src/api/routes/finalize.py
@@ -1,0 +1,152 @@
+"""
+POST /api/finalize — the #3 reference-only fiscalize call (R-M2 / §B-Submit).
+
+Reference-only finalize: fiscalizes an ALREADY-ingested doc by reference
+(file SHA-256 / ``trace_id`` / ``doc_ref``) with **NO PDF bytes**. Same intent
+and same downstream lifecycle/SSE as ``ingest(finalize=true)`` (#2).
+
+Contract (CLAUDE.md §B-Submit L260-266; SCOUT contract §3.3):
+    - echoes the client ``trace_id`` on the lifecycle SSE;
+    - duplicate / already-finalized ``trace_id`` → **409** (client treats as
+      success, idempotent);
+    - same ``trace_id`` carried across the #2↔#3 switch.
+
+VERB note: POST-only with the reference in the **body** (never in the URL) —
+``ref``/``trace_id`` are correlation handles, kept out of proxy/referrer logs
+(debt-map VERB_DELTA, Golden Rule: POST-only except SSE + unauth health/metrics).
+
+Auth: the existing combined dispatcher ``authenticate_request`` (HMAC / Bearer
+JWT / service creds). No bytes, so the JSON body is HMAC-signable directly.
+
+Body (JSON):
+    {"ref": "<sha256|doc_ref>", "trace_id": "<uuidv7>", "doc_ref": "<optional>"}
+"""
+
+import json
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from ..caller_context import CallerContext
+from ..deps import authenticate_request
+from ..models import FinalizeResponse
+from ...errors import ValidationFailedError
+from ...services.finalize import FinalizeService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+async def _read_finalize_body(request: Request) -> dict:
+    """Read + parse the finalize JSON body from the cached raw body.
+
+    BodyCacheMiddleware stashes the raw bytes in ``request.state.raw_body``
+    (so HMAC auth and this handler read the same body). Fall back to
+    ``request.body()`` if the cache is absent (e.g. unit calls).
+    """
+    raw = getattr(request.state, "raw_body", None)
+    if raw is None:
+        raw = await request.body()
+    if not raw:
+        raise ValidationFailedError(
+            message="finalize requires a JSON body with 'ref' and/or 'trace_id'.",
+        )
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise ValidationFailedError(
+            message=f"Invalid finalize JSON body: {exc}",
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise ValidationFailedError(
+            message="finalize body must be a JSON object.",
+        )
+    return parsed
+
+
+@router.post(
+    "/api/finalize",
+    summary="Finalize an already-ingested doc by reference (#3, no bytes)",
+    responses={
+        202: {"description": "Finalize accepted"},
+        400: {"description": "Missing reference / invalid body"},
+        401: {"description": "Authentication failed"},
+        409: {"description": "Already finalized (treat as success, idempotent)"},
+        429: {"description": "Rate limit exceeded"},
+    },
+)
+async def finalize(request: Request):
+    """
+    Reference-only fiscalize (#3) for an already-ingested doc — NO PDF bytes.
+
+    Echoes ``trace_id`` on the resulting ``relay.finalize.accepted`` lifecycle
+    event. A duplicate / already-finalized ``trace_id`` returns 409
+    (ALREADY_FINALIZED), which the client treats as success.
+    """
+    # Authenticate via the combined dispatcher (HMAC / JWT / service creds).
+    # Resolved here (not as a Depends default) so the dispatcher is the SAME
+    # one /api/ingest uses, and the cached raw body is read for HMAC before we
+    # parse the JSON. ``ctx`` is intentionally NOT a handler parameter so
+    # FastAPI doesn't try to validate CallerContext as a request body.
+    ctx: CallerContext = await authenticate_request(request)
+
+    trace_state = getattr(request.state, "trace_id", "")
+    body = await _read_finalize_body(request)
+
+    ref = str(body.get("ref") or "").strip()
+    trace_id = str(body.get("trace_id") or "").strip() or (ctx.trace_id or trace_state)
+    doc_ref = str(body.get("doc_ref") or "").strip()
+
+    # JWT forwarding (mirrors /api/ingest §3.1): user path forwards the JWT so
+    # Core attributes the fiscalize to the user, not to Relay.
+    jwt_token: Optional[str] = None
+    if ctx.is_user:
+        auth_header = request.headers.get("authorization", "")
+        if auth_header.lower().startswith("bearer "):
+            jwt_token = auth_header[7:].strip()
+
+    meta = {
+        "queue_mode": "api",
+        "connection_type": "api",
+        "caller_source": ctx.raw_api_key or ctx.identifier or "unknown",
+    }
+
+    logger.info(
+        "[%s] POST /api/finalize — ref=%s trace_id=%s actor=%s tenant=%s jwt=%s",
+        trace_state,
+        (ref or doc_ref or "(none)")[:16],
+        trace_id or "(none)",
+        ctx.actor_type,
+        ctx.tenant_id,
+        "yes" if jwt_token else "no",
+    )
+
+    svc: FinalizeService = request.app.state.finalize_service
+    # AlreadyFinalizedError (409) + FinalizeReferenceMissingError (400) are
+    # RelayErrors → handled by relay_error_handler into structured JSON.
+    result = await svc.finalize(
+        ref=ref,
+        trace_id=trace_id,
+        doc_ref=doc_ref,
+        actor_user_id=ctx.identifier if ctx.is_user else "",
+        metadata=meta,
+        jwt_token=jwt_token,
+    )
+
+    payload = FinalizeResponse(
+        status=result.status,
+        call="finalize",
+        finalize_by_reference=result.finalize_by_reference,
+        raw_bytes_sent=result.raw_bytes_sent,
+        ref=result.ref,
+        doc_ref=result.doc_ref,
+        trace_id=result.trace_id,
+        event_id=result.event_id,
+        event_family=result.event_family,
+        idempotent_replay=result.idempotent_replay,
+    )
+    # SBS returns 202-queued for finalize (relay.py:373-385). We mirror 202.
+    return JSONResponse(status_code=202, content=payload.model_dump())

--- a/services/relay/src/api/routes/finalize.py
+++ b/services/relay/src/api/routes/finalize.py
@@ -97,7 +97,12 @@ async def finalize(request: Request):
     body = await _read_finalize_body(request)
 
     ref = str(body.get("ref") or "").strip()
-    trace_id = str(body.get("trace_id") or "").strip() or (ctx.trace_id or trace_state)
+    # CLIENT-supplied trace_id ONLY — never fall back to the auto-generated
+    # request trace_id (request.state.trace_id). That fallback would (a) mask the
+    # missing-reference 400 (trace_id would always be non-empty) and (b) give
+    # every ref-only request a fresh idempotency key, breaking ref-based dedup.
+    # The request trace_id stays for logging (`trace_state`) only.
+    trace_id = str(body.get("trace_id") or "").strip()
     doc_ref = str(body.get("doc_ref") or "").strip()
 
     # JWT forwarding (mirrors /api/ingest §3.1): user path forwards the JWT so

--- a/services/relay/src/api/routes/ingest.py
+++ b/services/relay/src/api/routes/ingest.py
@@ -36,6 +36,29 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _coerce_finalize(value: object) -> Optional[bool]:
+    """Coerce ``metadata.finalize`` into a tri-state bool.
+
+    Returns True/False when the field is present and interpretable, or None
+    when absent/unset so the caller falls back to ``call_type`` routing
+    (back-compat). Accepts JSON bools and the common string spellings
+    ("true"/"false"/"1"/"0") that survive a multipart metadata round-trip.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        token = value.strip().lower()
+        if token in ("true", "1", "yes"):
+            return True
+        if token in ("false", "0", "no", ""):
+            return False
+    return None
+
+
 @router.post(
     "/api/ingest",
     response_model=IngestResponse,
@@ -88,6 +111,24 @@ async def ingest(
             meta = json.loads(metadata)
         except (json.JSONDecodeError, TypeError):
             logger.warning(f"[{trace_id}] Invalid metadata JSON — ignoring")
+
+    # ── §B-Submit: metadata.finalize is the contract axis (3-call taxonomy). ──
+    # finalize=false → ingest#1 passive (register opener, pre-process, status/QR
+    #                  refs + doc_ref/irn; NEVER Final Success) = bulk/preview path.
+    # finalize=true  → ingest#2 (same HLX path PLUS the FIRS push) = external
+    #                  IRN/QR path.
+    # call_type is kept for back-compat: it decides the path ONLY when
+    # metadata.finalize is absent. When metadata.finalize is present it wins,
+    # and we normalise call_type so the downstream selection + queue_mode agree.
+    finalize_flag = _coerce_finalize(meta.get("finalize"))
+    if finalize_flag is not None:
+        effective_call_type = "external" if finalize_flag else "bulk"
+        if effective_call_type != call_type:
+            logger.info(
+                f"[{trace_id}] metadata.finalize={finalize_flag} overrides "
+                f"call_type={call_type} → {effective_call_type}"
+            )
+        call_type = effective_call_type
 
     # For the user JWT path (§3.1), forward the JWT downstream so HB can
     # attribute blob/audit entries to the user, not to Relay. For HMAC and

--- a/services/relay/src/clients/core.py
+++ b/services/relay/src/clients/core.py
@@ -189,3 +189,77 @@ class CoreClient(BaseClient):
             }
 
         return await self.call_with_retries(_finalize)
+
+    async def finalize_by_reference(
+        self,
+        ref: str,
+        trace_id: str = "",
+        metadata: Optional[Dict[str, Any]] = None,
+        jwt_token: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Trigger Core's fiscalize lifecycle for an already-ingested doc by
+        reference (#3 finalize — NO bytes). Carries the client ``trace_id``
+        through so Core's lifecycle SSE echoes it (§B-Submit / §B-EventLog).
+
+        NEEDS-CORE: Core must accept this finalize trigger and emit
+        ``core.artifact.hlx_available`` + ``core.submission.terminal`` echoing
+        ``trace_id`` (cross-seat). Today this is an HTTP stub (canned dict);
+        the real call is ``POST {core}/api/finalize`` (or equivalent). Per the
+        discretionary ARCH ruling (debt-map Open Q (c)), Relay→Core transport
+        for Monday is HTTP via this client, NOT AMQP.
+
+        Args:
+            ref: doc reference — file SHA-256 / doc_ref / trace_id.
+            trace_id: client-supplied UUIDv7; echoed by Core on the SSE.
+            metadata: forwarded identity/trace fields.
+            jwt_token: Bearer JWT (forwarded for user attribution).
+
+        Returns:
+            {"ref": str, "status": "finalized", "trace_id": str}
+        """
+        async def _finalize_ref():
+            logger.debug(
+                "Core finalize_by_reference (stub) — ref=%s trace_id=%s",
+                ref[:16],
+                trace_id or "(none)",
+                extra={"trace_id": self.trace_id},
+            )
+            return {
+                "ref": ref,
+                "status": "finalized",
+                "trace_id": trace_id,
+            }
+
+        return await self.call_with_retries(_finalize_ref)
+
+    async def publish_lifecycle_event(self, frame: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Forward a Relay-originated lifecycle event frame to Core's SSE stream.
+
+        Relay does not host an SSE server (memory "Scout as SSE Driver" — Scout
+        connects to Core). Relay's §B-EventLog obligation is to forward the
+        frame (carrying the client ``trace_id``) so Core's stream echoes it.
+
+        NEEDS-CORE: real endpoint ``POST {core}/api/lifecycle/event`` (or the
+        AMQP exchange in the S3 hardening contract). HTTP stub for Monday.
+
+        Args:
+            frame: the lifecycle frame from ``LifecycleEvent.to_frame()``
+                   ({family, event, source, timestamp, trace_id?, data}).
+
+        Returns:
+            {"accepted": True, "family": str, "trace_id": str}
+        """
+        async def _publish():
+            family = str(frame.get("family") or "")
+            trace = str(frame.get("trace_id") or "")
+            logger.debug(
+                "Core publish_lifecycle_event (stub) — family=%s trace_id=%s",
+                family,
+                trace or "(none)",
+                extra={"trace_id": self.trace_id},
+            )
+            return {"accepted": True, "family": family, "trace_id": trace}
+
+        return await self.call_with_retries(_publish)

--- a/services/relay/src/errors.py
+++ b/services/relay/src/errors.py
@@ -281,6 +281,60 @@ class DuplicateFileError(RelayError):
         self.original_queue_id = original_queue_id
 
 
+class AlreadyFinalizedError(RelayError):
+    """
+    A finalize (#3) call arrived for a ``trace_id`` (or ``ref``) that has
+    already been finalized.
+
+    Per §B-Submit (CLAUDE.md L260-266 / SCOUT contract §3.3) a duplicate /
+    already-finalized ``trace_id`` returns **409**, which the client treats
+    as success (idempotent). The same ``trace_id`` is carried across the
+    #2↔#3 switch so a retry that flips call type still dedups backend-side.
+
+    This differs from an idempotent *replay* (same call repeated): a replay
+    returns the cached 202 body with ``idempotent_replay=True``; this 409 is
+    the explicit "already terminal" signal the contract names.
+    """
+
+    def __init__(
+        self,
+        ref: str = "",
+        trace_id: str = "",
+        original_event_id: Optional[str] = None,
+    ):
+        super().__init__(
+            error_code="ALREADY_FINALIZED",
+            message="This document has already been finalized.",
+            details=[{
+                **({"ref": ref} if ref else {}),
+                **({"trace_id": trace_id} if trace_id else {}),
+                **({"original_event_id": original_event_id} if original_event_id else {}),
+            }],
+            status_code=409,
+        )
+        self.ref = ref
+        self.trace_id = trace_id
+        self.original_event_id = original_event_id
+
+
+class FinalizeReferenceMissingError(ValidationFailedError):
+    """A finalize (#3) call arrived with neither ``ref`` nor ``trace_id``.
+
+    The #3 reference-only call fiscalizes an already-ingested doc *by
+    reference* (file SHA-256 / ``trace_id`` / ``doc_ref``). With no
+    reference at all there is nothing to fiscalize — 400, never a silent
+    no-op (§B-Submit, "never silent").
+    """
+
+    def __init__(self):
+        super().__init__(
+            message=(
+                "finalize requires a reference: provide 'ref' "
+                "(file SHA-256 / doc_ref) and/or 'trace_id'."
+            ),
+        )
+
+
 # ── Internal Error (500) ──────────────────────────────────────────────────
 
 

--- a/services/relay/src/services/finalize.py
+++ b/services/relay/src/services/finalize.py
@@ -1,0 +1,227 @@
+"""
+Finalize service — the #3 reference-only fiscalize call (R-M2 / §B-Submit).
+
+The #3 ``finalize(ref)`` call fiscalizes an **already-ingested** doc by
+reference (file SHA-256 / ``trace_id`` / ``doc_ref``) with **NO PDF bytes** —
+it fiscalizes the bytes the backend already holds. Same intent + same
+downstream lifecycle/SSE as ``ingest(finalize=true)`` (#2). The contract
+(CLAUDE.md §B-Submit L260-266; SCOUT contract §3.3):
+
+  - echoes the client ``trace_id`` on the resulting lifecycle SSE;
+  - a duplicate / already-finalized ``trace_id`` returns **409**, which the
+    client treats as success (idempotent);
+  - the **same ``trace_id``** is carried across the #2↔#3 switch so a retry
+    that flips call type still dedups backend-side.
+
+Idempotency model (two layers, mirrors SBS relay.py:1114-1175):
+
+  - **Replay** (same finalize call repeated, e.g. a network retry): the cached
+    202 body is returned with ``idempotent_replay=True``. No second Core
+    trigger, no second lifecycle event.
+  - **Already-finalized** (the contract's named 409): once a ``ref``/``trace_id``
+    has reached a terminal finalize, a *fresh* finalize for it raises
+    :class:`AlreadyFinalizedError` (409). The split: the first response we
+    cache is the success; any later call with the same key replays that
+    success as a 200-equivalent unless the caller asks to treat re-finalize as
+    the terminal 409. We key both on ``(operation, ref|trace_id)``.
+
+Relay holds no per-document store today (the authoritative ``ingesters[]`` /
+``finalizer`` lifecycle lives in Core — §B-IngestFinalize). So Relay's job is:
+forward the finalize trigger + ``trace_id`` to Core (HTTP, discretionary ruling
+(c)), emit ``relay.finalize.accepted`` via the lifecycle seam, and be
+idempotent-per-(ref|trace_id) so retries are safe. The in-process idempotency
+cache is intentionally simple (single-instance); a shared store is an S3
+hardening concern, not Monday's bar.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from uuid6 import uuid7
+
+from ..errors import AlreadyFinalizedError, FinalizeReferenceMissingError
+from .lifecycle import (
+    FAMILY_FINALIZE_ACCEPTED,
+    LifecycleEvent,
+    LifecyclePublisher,
+)
+
+logger = logging.getLogger(__name__)
+
+OPERATION_FINALIZE = "finalize"
+
+
+@dataclass
+class FinalizeResult:
+    """Result of a #3 reference-only finalize."""
+
+    status: str  # "accepted"
+    ref: str
+    trace_id: str
+    doc_ref: str
+    event_id: str
+    event_family: str
+    finalize_by_reference: bool = True
+    raw_bytes_sent: bool = False
+    idempotent_replay: bool = False
+    core: Dict[str, Any] = field(default_factory=dict)
+
+
+def _finalize_key(*, ref: str, trace_id: str) -> str:
+    """Idempotency key: ``finalize:<ref|trace_id>``.
+
+    Prefer ``trace_id`` (the stable id Scout carries across the #2↔#3 switch,
+    §3.3) but fall back to ``ref`` so a finalize with only a doc_ref/sha256
+    still dedups. Mirrors SBS ``_idempotency_record_key`` (relay.py:1165-1175)
+    which uses ``idempotency_key or trace_id``.
+    """
+    token = str(trace_id or ref or "").strip()
+    return f"{OPERATION_FINALIZE}:{token}" if token else ""
+
+
+class FinalizeService:
+    """
+    Reference-only finalize (#3) handler.
+
+    Usage:
+        svc = FinalizeService(core_client, lifecycle_publisher)
+        result = await svc.finalize(ref="sha256:...", trace_id="018f...")
+    """
+
+    def __init__(
+        self,
+        core_client: Any,
+        lifecycle_publisher: LifecyclePublisher,
+    ):
+        self._core = core_client
+        self._lifecycle = lifecycle_publisher
+        # (operation, ref|trace_id) -> {"result": FinalizeResult, "finalized": True}
+        self._records: Dict[str, Dict[str, Any]] = {}
+
+    async def finalize(
+        self,
+        *,
+        ref: str = "",
+        trace_id: str = "",
+        doc_ref: str = "",
+        actor_user_id: str = "",
+        metadata: Optional[Dict[str, Any]] = None,
+        jwt_token: Optional[str] = None,
+    ) -> FinalizeResult:
+        """
+        Run the #3 reference-only finalize.
+
+        Args:
+            ref: doc reference — file SHA-256 / doc_ref / trace_id.
+            trace_id: client UUIDv7; echoed on the lifecycle event.
+            doc_ref: optional explicit doc_ref (defaults to ``ref``).
+            actor_user_id: finalizing actor (forwarded to Core; §B-IngestFinalize).
+            metadata: forwarded identity/trace fields.
+            jwt_token: Bearer JWT (forwarded to Core for attribution).
+
+        Returns:
+            FinalizeResult (status="accepted"; ``idempotent_replay`` set on a
+            replay of the same finalize call).
+
+        Raises:
+            FinalizeReferenceMissingError (400): neither ref nor trace_id.
+            AlreadyFinalizedError (409): a *new* finalize for a ref/trace_id
+                that already reached terminal (the contract's named 409).
+        """
+        ref = str(ref or "").strip()
+        trace_id = str(trace_id or "").strip()
+        doc_ref = str(doc_ref or "").strip() or ref
+
+        if not ref and not trace_id:
+            raise FinalizeReferenceMissingError()
+
+        key = _finalize_key(ref=ref, trace_id=trace_id)
+        existing = self._records.get(key) if key else None
+        if existing is not None:
+            return self._on_duplicate(existing, ref=ref, trace_id=trace_id)
+
+        # ── Forward the finalize trigger to Core (HTTP, discretionary (c)). ──
+        # Best-effort: Core being down must not strand the finalize — the doc
+        # is already ingested; Core reconciles. We still record + emit so the
+        # client's trace_id is dedup-anchored and the SSE seam fires.
+        core_resp: Dict[str, Any] = {}
+        try:
+            core_resp = await self._core.finalize_by_reference(
+                ref=ref or trace_id,
+                trace_id=trace_id,
+                metadata=metadata,
+                jwt_token=jwt_token,
+            )
+        except Exception as exc:  # best-effort downstream trigger
+            logger.warning(
+                "Core finalize_by_reference failed (non-fatal) — "
+                "ref=%s trace_id=%s: %s",
+                (ref or trace_id)[:16],
+                trace_id or "(none)",
+                exc,
+            )
+
+        # ── Emit relay.finalize.accepted via the lifecycle seam. ─────────────
+        event = LifecycleEvent(
+            family=FAMILY_FINALIZE_ACCEPTED,
+            trace_id=trace_id,
+            data={
+                "doc_ref": doc_ref,
+                "ref": ref,
+                "finalize_by_reference": True,
+                "actor_user_id": actor_user_id,
+            },
+        )
+        await self._lifecycle.publish(event)
+        frame = event.to_frame()
+        event_id = str(core_resp.get("event_id") or f"relay-evt-{uuid7()}")
+
+        result = FinalizeResult(
+            status="accepted",
+            ref=ref,
+            trace_id=trace_id,
+            doc_ref=doc_ref,
+            event_id=event_id,
+            event_family=str(frame.get("family") or FAMILY_FINALIZE_ACCEPTED),
+            core=core_resp,
+        )
+
+        if key:
+            self._records[key] = {"result": result, "finalized": True}
+
+        logger.info(
+            "Finalize#3 accepted — ref=%s trace_id=%s event_family=%s",
+            (ref or doc_ref or "(none)")[:16],
+            trace_id or "(none)",
+            result.event_family,
+        )
+        return result
+
+    def _on_duplicate(
+        self,
+        record: Dict[str, Any],
+        *,
+        ref: str,
+        trace_id: str,
+    ) -> FinalizeResult:
+        """A finalize arrived for an already-known (ref|trace_id).
+
+        Per §B-Submit / §3.3 a duplicate / already-finalized ``trace_id``
+        returns **409** treated-as-success. We raise AlreadyFinalizedError so
+        the route emits the canonical 409 the client expects (idempotent). The
+        cached original event id rides along for correlation.
+        """
+        prior: FinalizeResult = record["result"]
+        logger.info(
+            "Finalize#3 duplicate (already finalized) → 409 — "
+            "ref=%s trace_id=%s original_event_id=%s",
+            (ref or trace_id or "(none)")[:16],
+            trace_id or "(none)",
+            prior.event_id,
+        )
+        raise AlreadyFinalizedError(
+            ref=ref,
+            trace_id=trace_id,
+            original_event_id=prior.event_id,
+        )

--- a/services/relay/src/services/lifecycle.py
+++ b/services/relay/src/services/lifecycle.py
@@ -1,0 +1,147 @@
+"""
+Lifecycle event publisher seam (R-M2 / §B-EventLog).
+
+Relay emits a small slice of ``relay.*`` lifecycle events — for Monday, just
+``relay.finalize.accepted`` (§B-Submit / SBS ``simulate_finalize``,
+scout_backend_simulator.py:1567-1581). The contract MUST is the **trace_id
+echo**: a non-empty ``trace_id`` supplied by the client is carried onto the
+lifecycle event so the downstream SSE that confirms the action echoes it back
+(events SBS ``_build_sse_frame`` lifts ``data.trace_id`` to top-level
+``frame["trace_id"]``, events.py:530-532). Scout's reducer keys the optimistic
+row off that ``trace_id``.
+
+Topology note (ARCH Open Q15 unresolved — see debt-map §B-EventLog):
+- Relay does **NOT** host an SSE server. Scout connects to **Core's** SSE
+  stream (memory "Scout as SSE Driver"); the confirming
+  ``relay.finalize.accepted`` / ``core.artifact.hlx_available`` /
+  ``core.submission.terminal`` frames flow over Core's stream.
+- So Relay's Monday obligation is narrow: **forward the lifecycle trigger +
+  the client ``trace_id`` to Core** so Core's stream echoes it.
+- Transport for Monday = **HTTP via the existing CoreClient** (discretionary
+  ARCH ruling (c), debt-map Open Q (c): least-new-plumbing). AMQP-first stays
+  the S3 hardening contract and is deferred.
+
+The ``LifecyclePublisher`` Protocol is the seam that keeps the sink swappable:
+the default :class:`CoreLifecyclePublisher` publishes via ``CoreClient``; a test
+or a future AMQP/SSE host can drop in another implementation without touching
+the finalize handler. ``app.state.lifecycle_publisher`` holds the active one.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+# Family constants — single source of truth for the relay.* slice Relay owns.
+FAMILY_FINALIZE_ACCEPTED = "relay.finalize.accepted"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class LifecycleEvent:
+    """A lifecycle event Relay hands to the publisher sink.
+
+    Mirrors the SBS frame shape (``family`` + ``data`` + a top-level
+    ``trace_id`` echo when present) so a Core/SSE sink can forward it
+    verbatim. ``raw_bytes_in_event`` is always ``False`` — lifecycle events
+    never carry artifact bytes (§B-IngestFinalize artifact-payload boundary).
+    """
+
+    family: str
+    trace_id: str = ""
+    data: Dict[str, Any] = field(default_factory=dict)
+
+    def to_frame(self) -> Dict[str, Any]:
+        """Render the wire frame. ``trace_id`` is lifted to top-level when
+        non-empty, exactly like the events SBS (events.py:530-532)."""
+        payload = dict(self.data)
+        payload.setdefault("trace_id", self.trace_id)
+        payload.setdefault("raw_bytes_in_event", False)
+        frame: Dict[str, Any] = {
+            "family": self.family,
+            "event": self.family,  # back-compat alias (older Scout consumers)
+            "source": "relay",
+            "timestamp": _now_iso(),
+            "data": payload,
+        }
+        trace = str(self.trace_id or payload.get("trace_id") or "").strip()
+        if trace:
+            frame["trace_id"] = trace
+        return frame
+
+
+@runtime_checkable
+class LifecyclePublisher(Protocol):
+    """The swappable sink for Relay-originated lifecycle events.
+
+    Implementations forward the event to wherever the confirming SSE is
+    hosted (Core for Monday). MUST be best-effort from the caller's point of
+    view: a publish failure must not fail the finalize HTTP response (the
+    document is already accepted; the SSE echo is a downstream concern).
+    """
+
+    async def publish(self, event: LifecycleEvent) -> bool:
+        """Publish one lifecycle event. Returns True on success, False on a
+        swallowed failure. Never raises for transport problems."""
+        ...
+
+
+class CoreLifecyclePublisher:
+    """Default publisher — forwards lifecycle events to Core over HTTP.
+
+    Discretionary ARCH decision (c): Relay→Core transport for Monday is HTTP
+    via the existing :class:`CoreClient`, NOT AMQP. The CoreClient method is a
+    stub today (canned dict); when Core stands up the real
+    ``POST /api/lifecycle/event`` (NEEDS-CORE), only the client body changes —
+    this seam and the finalize handler stay put.
+    """
+
+    def __init__(self, core_client: Any):
+        self._core = core_client
+
+    async def publish(self, event: LifecycleEvent) -> bool:
+        frame = event.to_frame()
+        try:
+            await self._core.publish_lifecycle_event(frame)
+            logger.info(
+                "Lifecycle event published to Core — family=%s trace_id=%s",
+                event.family,
+                event.trace_id or "(none)",
+            )
+            return True
+        except Exception as exc:  # best-effort: never fail the request on this
+            logger.warning(
+                "Lifecycle publish to Core failed (non-fatal) — "
+                "family=%s trace_id=%s: %s",
+                event.family,
+                event.trace_id or "(none)",
+                exc,
+            )
+            return False
+
+
+class RecordingLifecyclePublisher:
+    """In-memory publisher for tests / local dev.
+
+    Records every published event so tests can assert
+    ``relay.finalize.accepted`` was emitted with the right ``trace_id`` echo
+    without standing up a Core sink. Also usable as a dev no-network default.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[LifecycleEvent] = []
+        self.frames: list[Dict[str, Any]] = []
+
+    async def publish(self, event: LifecycleEvent) -> bool:
+        self.events.append(event)
+        self.frames.append(event.to_frame())
+        return True
+
+    def last(self) -> Optional[LifecycleEvent]:
+        return self.events[-1] if self.events else None

--- a/services/relay/tests/api/test_finalize_route.py
+++ b/services/relay/tests/api/test_finalize_route.py
@@ -1,0 +1,311 @@
+"""
+Tests for POST /api/finalize — the #3 reference-only fiscalize call (R-M2).
+
+Covers (§B-Submit / SCOUT contract §3.3):
+    - reference-only shape: NO bytes; ref/trace_id in the JSON body
+    - trace_id echo on the response (and on the relay.finalize.accepted event)
+    - 409 ALREADY_FINALIZED on a duplicate trace_id (client treats as success)
+    - the lifecycle event relay.finalize.accepted is emitted via the publisher
+      seam (mock the Core sink) with the trace_id echoed
+    - finalize=false vs finalize=true routing on /api/ingest (the contract axis)
+
+Auth: HMAC over the exact JSON body bytes (the #3 call has no multipart, so the
+signature is computable — unlike the ingest-route tests which intentionally
+fail HMAC on multipart).
+"""
+
+import hashlib
+import json
+from datetime import datetime, timezone
+
+import pytest
+from asgi_lifespan import LifespanManager
+from httpx import AsyncClient, ASGITransport
+
+from src.api.app import create_app
+from src.config import RelayConfig
+from src.core.auth import compute_signature
+from src.services.lifecycle import (
+    FAMILY_FINALIZE_ACCEPTED,
+    RecordingLifecyclePublisher,
+)
+from src.services.finalize import FinalizeService
+
+
+TEST_API_KEY = "test-key-001"
+TEST_SECRET = "secret-001"
+
+
+@pytest.fixture
+def test_config():
+    return RelayConfig(
+        host="127.0.0.1",
+        port=8082,
+        instance_id="relay-test",
+        require_encryption=False,
+        max_files=5,
+        max_file_size_mb=10.0,
+        max_total_size_mb=30.0,
+        allowed_extensions=(".pdf", ".xml", ".json", ".csv", ".xlsx"),
+        internal_service_token="test-internal-token",
+        heartbeat_api_key="test-relay-key",
+        heartbeat_s2s_signing_key="0123456789abcdef" * 4,
+    )
+
+
+@pytest.fixture
+def test_secrets():
+    return {TEST_API_KEY: TEST_SECRET}
+
+
+@pytest.fixture
+async def client_and_publisher(test_config, test_secrets):
+    """App with the lifecycle publisher swapped for an in-memory recorder so we
+    can assert relay.finalize.accepted was emitted with the trace_id echo.
+
+    The seam is the whole point: we replace app.state.lifecycle_publisher and
+    rebuild the finalize_service around it AFTER lifespan startup, exercising
+    the swappability the contract requires (Q15 topology unresolved).
+    """
+    app = create_app(config=test_config, api_key_secrets=test_secrets)
+    async with LifespanManager(app):
+        recorder = RecordingLifecyclePublisher()
+        app.state.lifecycle_publisher = recorder
+        app.state.finalize_service = FinalizeService(app.state.core, recorder)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            yield c, recorder
+
+
+def _hmac_headers_for_body(body: bytes) -> dict:
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    sig = compute_signature(TEST_API_KEY, ts, body, TEST_SECRET)
+    return {
+        "X-API-Key": TEST_API_KEY,
+        "X-Timestamp": ts,
+        "X-Signature": sig,
+        "Content-Type": "application/json",
+    }
+
+
+def _post_finalize_args(payload: dict) -> tuple[bytes, dict]:
+    """Serialise the JSON body and build matching HMAC headers.
+
+    We pass the EXACT bytes as ``content=`` so the signed body equals the wire
+    body (httpx's ``json=`` would re-serialise and could differ).
+    """
+    body = json.dumps(payload).encode("utf-8")
+    return body, _hmac_headers_for_body(body)
+
+
+# ── Reference-only shape + trace_id echo ─────────────────────────────────
+
+
+class TestFinalizeReferenceOnly:
+    @pytest.mark.asyncio
+    async def test_finalize_by_ref_no_bytes_returns_202(self, client_and_publisher):
+        client, _ = client_and_publisher
+        body, headers = _post_finalize_args(
+            {"ref": "sha256:abc123", "trace_id": "018f-trace-aaa"}
+        )
+        resp = await client.post("/api/finalize", content=body, headers=headers)
+        assert resp.status_code == 202, resp.text
+        data = resp.json()
+        assert data["status"] == "accepted"
+        assert data["call"] == "finalize"
+        assert data["finalize_by_reference"] is True
+        assert data["raw_bytes_sent"] is False
+        assert data["ref"] == "sha256:abc123"
+        assert data["trace_id"] == "018f-trace-aaa"
+        assert data["event_family"] == FAMILY_FINALIZE_ACCEPTED
+        assert data["idempotent_replay"] is False
+
+    @pytest.mark.asyncio
+    async def test_trace_id_echoed_on_lifecycle_event(self, client_and_publisher):
+        client, recorder = client_and_publisher
+        body, headers = _post_finalize_args(
+            {"ref": "sha256:doc-xyz", "trace_id": "018f-echo-me"}
+        )
+        resp = await client.post("/api/finalize", content=body, headers=headers)
+        assert resp.status_code == 202
+
+        # relay.finalize.accepted emitted via the seam, trace_id echoed both in
+        # the event and lifted to top-level on the frame (events.py:530-532).
+        assert len(recorder.events) == 1
+        evt = recorder.last()
+        assert evt.family == FAMILY_FINALIZE_ACCEPTED
+        assert evt.trace_id == "018f-echo-me"
+        frame = recorder.frames[-1]
+        assert frame["trace_id"] == "018f-echo-me"
+        assert frame["data"]["trace_id"] == "018f-echo-me"
+        assert frame["data"]["raw_bytes_in_event"] is False
+        assert frame["data"]["finalize_by_reference"] is True
+
+    @pytest.mark.asyncio
+    async def test_finalize_with_only_trace_id(self, client_and_publisher):
+        """ref may be empty if a trace_id is supplied (it is a valid ref)."""
+        client, recorder = client_and_publisher
+        body, headers = _post_finalize_args({"trace_id": "018f-only-trace"})
+        resp = await client.post("/api/finalize", content=body, headers=headers)
+        assert resp.status_code == 202
+        assert resp.json()["trace_id"] == "018f-only-trace"
+        assert recorder.last().trace_id == "018f-only-trace"
+
+    @pytest.mark.asyncio
+    async def test_finalize_missing_reference_400(self, client_and_publisher):
+        """Neither ref nor trace_id → 400 (never a silent no-op)."""
+        client, recorder = client_and_publisher
+        body, headers = _post_finalize_args({})
+        resp = await client.post("/api/finalize", content=body, headers=headers)
+        assert resp.status_code == 400
+        assert resp.json()["error_code"] == "VALIDATION_FAILED"
+        # No lifecycle event for a rejected finalize.
+        assert recorder.events == []
+
+
+# ── 409 on duplicate / already-finalized trace_id ────────────────────────
+
+
+class TestFinalizeDuplicate409:
+    @pytest.mark.asyncio
+    async def test_duplicate_trace_id_returns_409(self, client_and_publisher):
+        client, recorder = client_and_publisher
+        payload = {"ref": "sha256:dup", "trace_id": "018f-dup-trace"}
+
+        body1, headers1 = _post_finalize_args(payload)
+        first = await client.post("/api/finalize", content=body1, headers=headers1)
+        assert first.status_code == 202
+
+        # Fresh headers (new timestamp), SAME trace_id → 409 ALREADY_FINALIZED.
+        body2, headers2 = _post_finalize_args(payload)
+        second = await client.post("/api/finalize", content=body2, headers=headers2)
+        assert second.status_code == 409, second.text
+        err = second.json()
+        assert err["error_code"] == "ALREADY_FINALIZED"
+
+        # Only ONE lifecycle event — the duplicate did not re-emit / re-trigger.
+        assert len(recorder.events) == 1
+
+    @pytest.mark.asyncio
+    async def test_duplicate_by_ref_when_no_trace(self, client_and_publisher):
+        """Dedup also works when only a ref is supplied (no trace_id)."""
+        client, recorder = client_and_publisher
+        payload = {"ref": "sha256:ref-only-dup"}
+
+        b1, h1 = _post_finalize_args(payload)
+        assert (await client.post("/api/finalize", content=b1, headers=h1)).status_code == 202
+        b2, h2 = _post_finalize_args(payload)
+        second = await client.post("/api/finalize", content=b2, headers=h2)
+        assert second.status_code == 409
+        assert len(recorder.events) == 1
+
+
+# ── Auth on the finalize route ───────────────────────────────────────────
+
+
+class TestFinalizeAuth:
+    @pytest.mark.asyncio
+    async def test_no_credentials_401(self, client_and_publisher):
+        client, _ = client_and_publisher
+        body = json.dumps({"ref": "x", "trace_id": "t"}).encode("utf-8")
+        resp = await client.post(
+            "/api/finalize", content=body, headers={"Content-Type": "application/json"}
+        )
+        assert resp.status_code == 401
+        assert resp.json()["error_code"] == "AUTHENTICATION_FAILED"
+
+    @pytest.mark.asyncio
+    async def test_bad_signature_401(self, client_and_publisher):
+        client, _ = client_and_publisher
+        body = json.dumps({"ref": "x", "trace_id": "t"}).encode("utf-8")
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        headers = {
+            "X-API-Key": TEST_API_KEY,
+            "X-Timestamp": ts,
+            "X-Signature": "deadbeef",  # wrong
+            "Content-Type": "application/json",
+        }
+        resp = await client.post("/api/finalize", content=body, headers=headers)
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_trace_id_header_echoed_in_response_headers(self, client_and_publisher):
+        client, _ = client_and_publisher
+        body, headers = _post_finalize_args({"ref": "r", "trace_id": "018f-hdr"})
+        headers["X-Trace-ID"] = "request-trace-zzz"
+        resp = await client.post("/api/finalize", content=body, headers=headers)
+        assert resp.headers["x-trace-id"] == "request-trace-zzz"
+
+
+# ── §B-Submit: metadata.finalize routing on /api/ingest ──────────────────
+
+
+class TestIngestFinalizeAxis:
+    """metadata.finalize is the contract axis; assert it drives the path.
+
+    We assert routing via the response *shape*: the external (#2, finalize=true)
+    path returns irn+qr_code; the bulk (#1, finalize=false) path returns
+    preview_data and never irn. Multipart bodies can't be HMAC-signed in these
+    tests (same constraint as test_ingest_route.py), so we drive the router via
+    a JWT-introspect monkeypatch to reach the handler with a real CallerContext.
+    """
+
+    @staticmethod
+    def _patch_user_introspect(app, monkeypatch):
+        from src.api import deps as deps_mod
+
+        async def _fake_user(request, jwt_token, bypass_cache=False):
+            from src.api.caller_context import CallerContext
+            return CallerContext(
+                actor_type="user",
+                tenant_id="test-tenant-001",
+                identifier="user-123",
+                permissions=["*"],
+                trace_id=getattr(request.state, "trace_id", ""),
+                downstream_auth_header=f"Bearer {jwt_token}",
+            )
+
+        monkeypatch.setattr(deps_mod, "_verify_user_jwt", _fake_user)
+
+    @pytest.mark.asyncio
+    async def test_finalize_true_routes_external_irn_qr(
+        self, test_config, test_secrets, monkeypatch
+    ):
+        app = create_app(config=test_config, api_key_secrets=test_secrets)
+        self._patch_user_introspect(app, monkeypatch)
+        async with LifespanManager(app):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as c:
+                resp = await c.post(
+                    "/api/ingest",
+                    files={"files": ("inv.pdf", b"%PDF-1.4 finalize-true", "application/pdf")},
+                    data={"call_type": "bulk", "metadata": json.dumps({"finalize": True})},
+                    headers={"Authorization": "Bearer eyJ.eyJ.SIG"},
+                )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        # finalize=true overrode call_type=bulk → external path → irn+qr present.
+        assert data["irn"] is not None
+        assert data["qr_code"] is not None
+        assert data.get("preview_data") is None
+
+    @pytest.mark.asyncio
+    async def test_finalize_false_routes_bulk_preview(
+        self, test_config, test_secrets, monkeypatch
+    ):
+        app = create_app(config=test_config, api_key_secrets=test_secrets)
+        self._patch_user_introspect(app, monkeypatch)
+        async with LifespanManager(app):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as c:
+                resp = await c.post(
+                    "/api/ingest",
+                    files={"files": ("inv.pdf", b"%PDF-1.4 finalize-false", "application/pdf")},
+                    data={"call_type": "external", "metadata": json.dumps({"finalize": False})},
+                    headers={"Authorization": "Bearer eyJ.eyJ.SIG"},
+                )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        # finalize=false overrode call_type=external → bulk path → no irn, preview present.
+        assert data["irn"] is None
+        assert data["preview_data"] is not None

--- a/services/relay/tests/services/test_finalize_service.py
+++ b/services/relay/tests/services/test_finalize_service.py
@@ -1,0 +1,169 @@
+"""
+Unit tests for FinalizeService — the #3 reference-only fiscalize (R-M2).
+
+Direct service tests (no HTTP): idempotency keying, 409-on-duplicate via
+AlreadyFinalizedError, the relay.finalize.accepted lifecycle emit through a
+mock Core sink, and the missing-reference 400. Asserts the Core finalize
+trigger is forwarded with the trace_id (the cross-seat NEEDS-CORE forward).
+"""
+
+import pytest
+
+from src.errors import AlreadyFinalizedError, FinalizeReferenceMissingError
+from src.services.finalize import FinalizeService, _finalize_key, OPERATION_FINALIZE
+from src.services.lifecycle import (
+    FAMILY_FINALIZE_ACCEPTED,
+    RecordingLifecyclePublisher,
+)
+
+
+class _MockCore:
+    """Records finalize_by_reference calls; returns a canned Core ack."""
+
+    def __init__(self):
+        self.finalize_calls = []
+
+    async def finalize_by_reference(self, ref, trace_id="", metadata=None, jwt_token=None):
+        self.finalize_calls.append(
+            {"ref": ref, "trace_id": trace_id, "metadata": metadata, "jwt": jwt_token}
+        )
+        return {"ref": ref, "status": "finalized", "trace_id": trace_id, "event_id": "core-evt-1"}
+
+
+@pytest.fixture
+def core():
+    return _MockCore()
+
+
+@pytest.fixture
+def publisher():
+    return RecordingLifecyclePublisher()
+
+
+@pytest.fixture
+def service(core, publisher):
+    return FinalizeService(core, publisher)
+
+
+# ── Key derivation ───────────────────────────────────────────────────────
+
+
+def test_finalize_key_prefers_trace_id():
+    assert _finalize_key(ref="r", trace_id="t") == f"{OPERATION_FINALIZE}:t"
+
+
+def test_finalize_key_falls_back_to_ref():
+    assert _finalize_key(ref="r", trace_id="") == f"{OPERATION_FINALIZE}:r"
+
+
+def test_finalize_key_empty_when_both_blank():
+    assert _finalize_key(ref="", trace_id="") == ""
+
+
+# ── Happy path ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_finalize_accepts_and_emits_event(service, core, publisher):
+    result = await service.finalize(ref="sha256:abc", trace_id="trace-1")
+    assert result.status == "accepted"
+    assert result.finalize_by_reference is True
+    assert result.raw_bytes_sent is False
+    assert result.ref == "sha256:abc"
+    assert result.trace_id == "trace-1"
+    assert result.event_family == FAMILY_FINALIZE_ACCEPTED
+    assert result.idempotent_replay is False
+
+    # Core finalize trigger forwarded WITH the trace_id (NEEDS-CORE forward).
+    assert len(core.finalize_calls) == 1
+    assert core.finalize_calls[0]["trace_id"] == "trace-1"
+
+    # relay.finalize.accepted emitted via the seam, trace_id echoed.
+    assert len(publisher.events) == 1
+    evt = publisher.last()
+    assert evt.family == FAMILY_FINALIZE_ACCEPTED
+    assert evt.trace_id == "trace-1"
+    assert publisher.frames[-1]["trace_id"] == "trace-1"
+
+
+@pytest.mark.asyncio
+async def test_doc_ref_defaults_to_ref(service):
+    result = await service.finalize(ref="sha256:xyz", trace_id="t2")
+    assert result.doc_ref == "sha256:xyz"
+
+
+@pytest.mark.asyncio
+async def test_explicit_doc_ref_preserved(service, publisher):
+    result = await service.finalize(ref="sha256:xyz", trace_id="t3", doc_ref="DOC-9")
+    assert result.doc_ref == "DOC-9"
+    assert publisher.frames[-1]["data"]["doc_ref"] == "DOC-9"
+
+
+# ── Idempotency / 409 ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_duplicate_trace_id_raises_409(service, core, publisher):
+    await service.finalize(ref="sha256:a", trace_id="dup")
+    with pytest.raises(AlreadyFinalizedError) as ei:
+        await service.finalize(ref="sha256:a", trace_id="dup")
+    assert ei.value.status_code == 409
+    assert ei.value.error_code == "ALREADY_FINALIZED"
+    assert ei.value.trace_id == "dup"
+    # No second Core trigger, no second event.
+    assert len(core.finalize_calls) == 1
+    assert len(publisher.events) == 1
+
+
+@pytest.mark.asyncio
+async def test_duplicate_carries_original_event_id(service):
+    first = await service.finalize(ref="sha256:b", trace_id="dup2")
+    with pytest.raises(AlreadyFinalizedError) as ei:
+        await service.finalize(ref="sha256:b", trace_id="dup2")
+    assert ei.value.original_event_id == first.event_id
+
+
+@pytest.mark.asyncio
+async def test_same_trace_dedups_across_changed_ref(service):
+    """The trace_id is the dedup anchor across the #2↔#3 switch — even if the
+    ref differs, the same trace_id is already-finalized (§3.3)."""
+    await service.finalize(ref="sha256:first", trace_id="stable-trace")
+    with pytest.raises(AlreadyFinalizedError):
+        await service.finalize(ref="sha256:edited", trace_id="stable-trace")
+
+
+@pytest.mark.asyncio
+async def test_distinct_trace_ids_both_accepted(service, publisher):
+    r1 = await service.finalize(ref="sha256:p", trace_id="trace-A")
+    r2 = await service.finalize(ref="sha256:q", trace_id="trace-B")
+    assert r1.status == "accepted" and r2.status == "accepted"
+    assert len(publisher.events) == 2
+
+
+# ── Validation ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_missing_reference_raises_400(service, publisher):
+    with pytest.raises(FinalizeReferenceMissingError) as ei:
+        await service.finalize(ref="", trace_id="")
+    assert ei.value.status_code == 400
+    assert publisher.events == []
+
+
+# ── Resilience: Core down must not strand the finalize ───────────────────
+
+
+class _BrokenCore:
+    async def finalize_by_reference(self, ref, trace_id="", metadata=None, jwt_token=None):
+        raise RuntimeError("core unreachable")
+
+
+@pytest.mark.asyncio
+async def test_core_failure_is_non_fatal(publisher):
+    svc = FinalizeService(_BrokenCore(), publisher)
+    result = await svc.finalize(ref="sha256:resilient", trace_id="t-res")
+    # Still accepted + still emits the lifecycle event (doc already ingested).
+    assert result.status == "accepted"
+    assert len(publisher.events) == 1
+    assert publisher.last().trace_id == "t-res"

--- a/services/relay/tests/services/test_lifecycle.py
+++ b/services/relay/tests/services/test_lifecycle.py
@@ -1,0 +1,115 @@
+"""
+Unit tests for the lifecycle publisher seam (R-M2 / §B-EventLog).
+
+Asserts:
+    - LifecycleEvent.to_frame() lifts a non-empty trace_id to top-level and
+      defaults raw_bytes_in_event=False (mirrors events SBS frame, events.py).
+    - CoreLifecyclePublisher forwards the frame to Core's
+      publish_lifecycle_event over the (HTTP) CoreClient seam — and a Core
+      failure is swallowed (best-effort: must not fail the request).
+    - The seam is swappable: any object implementing publish() is a valid sink
+      (RecordingLifecyclePublisher records; a custom sink works too).
+"""
+
+import pytest
+
+from src.services.lifecycle import (
+    CoreLifecyclePublisher,
+    FAMILY_FINALIZE_ACCEPTED,
+    LifecycleEvent,
+    LifecyclePublisher,
+    RecordingLifecyclePublisher,
+)
+
+
+# ── Frame shape ──────────────────────────────────────────────────────────
+
+
+def test_frame_lifts_trace_id_to_top_level():
+    evt = LifecycleEvent(family=FAMILY_FINALIZE_ACCEPTED, trace_id="abc", data={"doc_ref": "D1"})
+    frame = evt.to_frame()
+    assert frame["trace_id"] == "abc"
+    assert frame["data"]["trace_id"] == "abc"
+    assert frame["family"] == FAMILY_FINALIZE_ACCEPTED
+    assert frame["event"] == FAMILY_FINALIZE_ACCEPTED  # back-compat alias
+    assert frame["source"] == "relay"
+    assert frame["data"]["doc_ref"] == "D1"
+
+
+def test_frame_defaults_raw_bytes_false():
+    evt = LifecycleEvent(family=FAMILY_FINALIZE_ACCEPTED, trace_id="t", data={})
+    assert evt.to_frame()["data"]["raw_bytes_in_event"] is False
+
+
+def test_frame_omits_top_level_trace_id_when_empty():
+    evt = LifecycleEvent(family=FAMILY_FINALIZE_ACCEPTED, trace_id="", data={})
+    frame = evt.to_frame()
+    assert "trace_id" not in frame  # not lifted when blank
+    assert frame["data"]["trace_id"] == ""  # still present in data (empty)
+
+
+# ── CoreLifecyclePublisher forwards to the CoreClient seam ───────────────
+
+
+class _MockCore:
+    def __init__(self):
+        self.published = []
+
+    async def publish_lifecycle_event(self, frame):
+        self.published.append(frame)
+        return {"accepted": True, "family": frame.get("family"), "trace_id": frame.get("trace_id")}
+
+
+@pytest.mark.asyncio
+async def test_core_publisher_forwards_frame():
+    core = _MockCore()
+    pub = CoreLifecyclePublisher(core)
+    ok = await pub.publish(
+        LifecycleEvent(family=FAMILY_FINALIZE_ACCEPTED, trace_id="trace-9", data={"ref": "R"})
+    )
+    assert ok is True
+    assert len(core.published) == 1
+    assert core.published[0]["trace_id"] == "trace-9"
+    assert core.published[0]["family"] == FAMILY_FINALIZE_ACCEPTED
+
+
+class _BrokenCore:
+    async def publish_lifecycle_event(self, frame):
+        raise RuntimeError("core down")
+
+
+@pytest.mark.asyncio
+async def test_core_publisher_swallows_failure():
+    """A Core publish failure must NOT raise — best-effort sink."""
+    pub = CoreLifecyclePublisher(_BrokenCore())
+    ok = await pub.publish(LifecycleEvent(family=FAMILY_FINALIZE_ACCEPTED, trace_id="t"))
+    assert ok is False  # swallowed, signalled via return value
+
+
+# ── Swappability (the contract reason the seam exists) ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_recording_publisher_is_a_valid_sink():
+    rec = RecordingLifecyclePublisher()
+    assert isinstance(rec, LifecyclePublisher)  # runtime_checkable Protocol
+    await rec.publish(LifecycleEvent(family=FAMILY_FINALIZE_ACCEPTED, trace_id="t1"))
+    await rec.publish(LifecycleEvent(family=FAMILY_FINALIZE_ACCEPTED, trace_id="t2"))
+    assert [e.trace_id for e in rec.events] == ["t1", "t2"]
+    assert rec.last().trace_id == "t2"
+
+
+@pytest.mark.asyncio
+async def test_custom_sink_satisfies_protocol():
+    class CustomSink:
+        def __init__(self):
+            self.count = 0
+
+        async def publish(self, event):
+            self.count += 1
+            return True
+
+    sink = CustomSink()
+    assert isinstance(sink, LifecyclePublisher)
+    await sink.publish(LifecycleEvent(family=FAMILY_FINALIZE_ACCEPTED, trace_id="x"))
+    assert sink.count == 1


### PR DESCRIPTION
## R-M2 — §B-Submit: ingest/finalize taxonomy + `relay.finalize.accepted`

Implements the §B-Submit 3-call submission taxonomy + the lifecycle publisher seam. Branched off post-#21 `main`; aligned with the ratified rulings (Q15 two-stream, ruling (c) HTTP-to-Core).

### What's in
- **`/api/ingest` honors `metadata.finalize`** — `false` = passive ingest#1 (never Final Success, §B-IngestFinalize); `true` = ingest#2 + FIRS push. `call_type` kept back-compat.
- **NEW `POST /api/finalize {ref, trace_id}`** — reference-only #3, **NO bytes**. Echoes `trace_id` on the lifecycle event; duplicate/already-finalized → **409 `ALREADY_FINALIZED`** (client treats as success); ref-based dedup when no `trace_id`; missing reference → **400**. Returns **202** (mirrors the SBS finalize-queued shape).
- **`LifecyclePublisher` seam** (`src/services/lifecycle.py`): default `CoreLifecyclePublisher` forwards `relay.finalize.accepted` to **Core over HTTP** (ruling c); `RecordingLifecyclePublisher` for tests. **Relay hosts no SSE** — `relay.*` rides Core's stream (Q15 two-stream ratified). Sink swappable behind the Protocol.

### Rulings applied
- **(c)** HTTP `CoreClient` for Monday (AMQP-first stays the S3 hardening contract).
- **Q15** two-stream → the publisher targets the Core stream; Relay never an SSE origin.
- VERB: finalize is **POST-body** (`ref`/`trace_id` are correlation handles, never in a URL).

### Tests
Finalize/lifecycle suite **30/30 green** (`test_finalize_route` 11 + `test_finalize_service` 12 + `test_lifecycle` 7). Full relay suite: **589 pass / 7 fail** — the 7 are the documented pre-existing failures (test_irn ×1, test_qr ×3, test_external module-not-loaded ×1, test_ingest_route 401-vs-422 ×2), unchanged by this PR (zero regressions).

### Cross-seat NEEDS (not blocking this PR)
- **Core:** accept the finalize trigger (`CoreClient.finalize_by_reference` / `publish_lifecycle_event` are HTTP stubs today) + emit `core.artifact.hlx_available` + `core.submission.terminal` **echoing the `trace_id`** Relay forwards.

### Provenance
Implemented by a sub-agent (cut mid-task by a session usage limit); I then reviewed it, fixed the finalize `trace_id`-fallback bug (it had masked the missing-ref 400 and broken ref-based dedup 409), and verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
