### PR TITLE
feat(relay): R-M3 B-Drift — version-axis 409 gateway (X-Helium-* 5-axis)

### DIFF
--- a/services/relay/src/api/app.py
+++ b/services/relay/src/api/app.py
@@ -36,6 +36,7 @@ from ..services.finalize import FinalizeService
 from ..services.ingestion import IngestionService
 from ..services.lifecycle import CoreLifecyclePublisher
 from .middleware import BodyCacheMiddleware, TraceIDMiddleware, relay_error_handler
+from .version_drift import VersionDriftError, version_drift_error_handler
 from .routes.duplicate import router as duplicate_router
 from .routes.finalize import router as finalize_router
 from .routes.health import router as health_router
@@ -212,6 +213,9 @@ def create_app(
 
     # Error handlers
     app.add_exception_handler(RelayError, relay_error_handler)
+    # §B-Drift: version_drift 409 has a bespoke body shape (no RelayError
+    # wrapper) — rendered verbatim by its own handler.
+    app.add_exception_handler(VersionDriftError, version_drift_error_handler)
 
     # Routes
     app.include_router(health_router)

--- a/services/relay/src/api/routes/finalize.py
+++ b/services/relay/src/api/routes/finalize.py
@@ -26,12 +26,13 @@ import json
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 
 from ..caller_context import CallerContext
 from ..deps import authenticate_request
 from ..models import FinalizeResponse
+from ..version_drift import version_drift_guard
 from ...errors import ValidationFailedError
 from ...services.finalize import FinalizeService
 
@@ -70,11 +71,17 @@ async def _read_finalize_body(request: Request) -> dict:
 @router.post(
     "/api/finalize",
     summary="Finalize an already-ingested doc by reference (#3, no bytes)",
+    # §B-Drift: version-drift gateway runs BEFORE the handler body. On a stale
+    # version axis it raises 409 {code,axis,expected,got} and the fiscalize is
+    # NOT forwarded. The guard depends on authenticate_request; the handler
+    # re-resolves auth internally (idempotent: HMAC recompute / cached
+    # introspect) since it intentionally does not take ``ctx`` as a parameter.
+    dependencies=[Depends(version_drift_guard)],
     responses={
         202: {"description": "Finalize accepted"},
         400: {"description": "Missing reference / invalid body"},
         401: {"description": "Authentication failed"},
-        409: {"description": "Already finalized (treat as success, idempotent)"},
+        409: {"description": "Already finalized (idempotent) / version drift"},
         429: {"description": "Rate limit exceeded"},
     },
 )

--- a/services/relay/src/api/routes/ingest.py
+++ b/services/relay/src/api/routes/ingest.py
@@ -28,6 +28,7 @@ from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
 from ..caller_context import CallerContext
 from ..deps import authenticate_request, decrypt_body_if_needed
 from ..models import IngestResponse
+from ..version_drift import version_drift_guard
 from ...services.bulk import BulkService
 from ...services.external import ExternalService
 
@@ -63,11 +64,17 @@ def _coerce_finalize(value: object) -> Optional[bool]:
     "/api/ingest",
     response_model=IngestResponse,
     summary="Ingest files for processing",
+    # §B-Drift: version-drift gateway runs BEFORE the handler. On a stale
+    # version axis it raises 409 {code,axis,expected,got} and the request is
+    # NOT forwarded (no ingestion side effects). The guard shares the same
+    # authenticate_request dependency as the ``ctx`` handler param (FastAPI
+    # dedupes), so auth resolves once.
+    dependencies=[Depends(version_drift_guard)],
     responses={
         400: {"description": "Validation failed / Malware detected"},
         401: {"description": "Authentication failed"},
         403: {"description": "Encryption required"},
-        409: {"description": "Duplicate file"},
+        409: {"description": "Duplicate file / version drift"},
         429: {"description": "Rate limit exceeded"},
         503: {"description": "Module not loaded (external flow)"},
     },

--- a/services/relay/src/api/version_drift.py
+++ b/services/relay/src/api/version_drift.py
@@ -1,0 +1,315 @@
+"""
+Version-drift gateway guard (§B-Drift / §B-VersionAxes).
+
+Implements the Relay obligation from the Scout repo CLAUDE.md
+"Backend Debt Notes":
+
+    §B-Drift: Relay MUST act as the front-door gateway for every sensitive
+    mutating API call and check the incoming request's version axes against its
+    authoritative current values BEFORE forwarding to Core/Edge/FIRS. On a stale
+    axis it MUST return HTTP 409 with body
+    ``{"code": "version_drift", "axis": <axis>, "expected": <expected>, "got": <got>}``
+    and NOT forward the request (no backend side effects).
+
+    §B-VersionAxes: the contract covers FIVE state axes, not just
+    ``policy_revision`` — see the canonical header map below.
+
+This module is the executable mirror of the SBS spec at
+``scout_backend_simulator_relay.py`` (``_drift_response_if_needed``,
+``_drift_response``, ``_normalise_axis_name``). It is a reusable FastAPI
+dependency mounted on the sensitive mutating routes ``/api/ingest`` and
+``/api/finalize``.
+
+CANON (ratified Q17 — five axes, ``X-Helium-*`` wire headers)
+-------------------------------------------------------------
+The wire contract is the five ``X-Helium-*`` request headers below. The older
+SBS ``policy_revision`` / colon-named / bare-name spellings are a MOCK-only
+artefact (SBS impersonates Relay today); they are NOT the wire contract and are
+deliberately NOT accepted here. The header→axis map is configurable (a
+module-level dict, overridable via :func:`make_version_drift_guard`) so a
+≤cosmetic rename from HB-S3/S4 lands in one place.
+
+| Wire header                           | Axis                  |
+|---------------------------------------|-----------------------|
+| ``X-Helium-Policy-Revision``          | ``policy_revision``   |
+| ``X-Helium-License-State``            | ``license_state_id``  |
+| ``X-Helium-Usage-State``              | ``usage_state_id``    |
+| ``X-Helium-Auth-Policy-Revision``     | ``auth_policy_revision`` |
+| ``X-Helium-User-Permissions-Revision``| ``user_permissions`` (composite) |
+
+The composite ``user_permissions`` axis expands server-side to
+``user_permissions:<user_id>`` where ``<user_id>`` is the caller's JWT-derived
+identity (``CallerContext.identifier`` for the user actor) — NOT a sibling
+request header. A non-user caller (HMAC/ERP, service creds) has no user
+identity, so the composite axis is skipped for them.
+
+Authoritative values + the NEEDS-HB skip
+-----------------------------------------
+Authoritative axis values come from a *pluggable accessor*
+(:func:`_config_cache_axis_value`) reading ``app.state.config_cache``. Today the
+cache only tracks ``policy_revision``; the accessor probes each axis key
+generically (top-level then under ``tenant``) so axes the HB config fabric
+starts feeding (``license_state_id`` / ``usage_state_id`` /
+``auth_policy_revision``) light up automatically with no code change. An axis
+whose authoritative value is unknown returns ``None`` and is SKIPPED — it cannot
+drift until HB feeds it.
+
+NEEDS-HB: HB-S3/S4 must (a) feed ``license_state_id`` / ``usage_state_id`` /
+``auth_policy_revision`` (and the per-user permissions revision) into the
+tenant config Relay caches, and (b) confirm the final ``X-Helium-*`` header
+spellings. Expect at most a cosmetic rename of the header map.
+
+Pass-through rules (mirror SBS):
+  * Absent axis headers always pass through.
+  * A supplied axis whose authoritative value is unknown passes through (skip).
+  * Drift (409) is raised only for a SUPPLIED axis that mismatches a KNOWN
+    authoritative value — and is raised BEFORE the handler body runs, so the
+    request is never forwarded (no backend side effects).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, Mapping, Optional
+
+from fastapi import Depends, Request
+from fastapi.responses import JSONResponse
+
+from .caller_context import CallerContext
+from .deps import authenticate_request
+
+logger = logging.getLogger(__name__)
+
+
+# ── Canonical header → axis map (CANON: Q17 five ``X-Helium-*`` axes) ──────
+#
+# Keys are lowercase (HTTP header lookups are case-insensitive; Starlette's
+# ``request.headers`` is a case-insensitive multidict, but we lowercase on both
+# sides to be explicit). Configurable so a ≤cosmetic HB-S3/S4 rename lands in
+# one place (NEEDS-HB).
+DEFAULT_HEADER_AXIS_MAP: Dict[str, str] = {
+    "x-helium-policy-revision": "policy_revision",
+    "x-helium-license-state": "license_state_id",
+    "x-helium-usage-state": "usage_state_id",
+    "x-helium-auth-policy-revision": "auth_policy_revision",
+    # Composite per-user permissions axis. The supplied value is the
+    # permissions revision; the axis name in the 409 body becomes
+    # ``user_permissions:<user_id>`` where <user_id> is derived SERVER-SIDE
+    # from the caller's JWT identity (CallerContext.identifier), matching SBS
+    # ``relay_axis_headers_for_current_state`` → ``user_permissions:<user_id>``.
+    "x-helium-user-permissions-revision": "user_permissions",
+}
+
+# The composite axis name as it appears in the header map (pre-expansion).
+_COMPOSITE_USER_PERMISSIONS_AXIS = "user_permissions"
+
+
+class VersionDriftError(Exception):
+    """
+    Raised by the guard when a supplied version axis is stale.
+
+    Deliberately NOT a subclass of :class:`src.errors.RelayError`: the
+    §B-Drift contract pins the response body to the EXACT shape
+    ``{"code": "version_drift", "axis", "expected", "got"}`` with no
+    ``status``/``error_code``/``message`` wrapper. ``RelayError.to_dict()``
+    produces a different shape, so this error carries its own body and is
+    rendered verbatim by :func:`version_drift_error_handler`.
+    """
+
+    status_code = 409
+
+    def __init__(self, *, axis: str, expected: str, got: str):
+        self.axis = axis
+        self.expected = expected
+        self.got = got
+        super().__init__(f"version_drift on axis={axis}: expected={expected} got={got}")
+
+    def to_body(self) -> Dict[str, str]:
+        """Exact 409 body per §B-Drift (mirror of SBS ``_drift_response``)."""
+        return {
+            "code": "version_drift",
+            "axis": self.axis,
+            "expected": self.expected,
+            "got": self.got,
+        }
+
+
+async def version_drift_error_handler(
+    request: Request, exc: VersionDriftError
+) -> JSONResponse:
+    """Render :class:`VersionDriftError` as the verbatim 409 §B-Drift body."""
+    logger.info(
+        "[%s] version_drift axis=%s expected=%s got=%s",
+        getattr(request.state, "trace_id", "unknown"),
+        exc.axis,
+        exc.expected,
+        exc.got,
+    )
+    return JSONResponse(status_code=exc.status_code, content=exc.to_body())
+
+
+def _config_cache_axis_value(config_cache: Any, axis: str) -> Optional[str]:
+    """
+    Pluggable authoritative-value accessor backed by ``ConfigCache``.
+
+    Returns the authoritative current value for ``axis``, or ``None`` when the
+    axis is not yet tracked (→ caller SKIPS it; NEEDS-HB).
+
+    The lookup is generic so axes the HB config fabric starts feeding light up
+    with no code change:
+      1. top-level cached config key (``config_cache.get(axis)``);
+      2. the same key nested under the ``tenant`` section.
+
+    Today only ``policy_revision`` is present in the cached config shape, so the
+    other first-class axes (``license_state_id`` / ``usage_state_id`` /
+    ``auth_policy_revision``) and the composite ``user_permissions:<uid>`` axis
+    resolve to ``None`` until HB feeds them (NEEDS-HB).
+    """
+    if config_cache is None:
+        return None
+
+    # The composite per-user axis (``user_permissions:<uid>``) is not in the
+    # cached tenant config shape yet — it needs a per-user revision fabric from
+    # HB. Skip it explicitly so we don't accidentally read a top-level
+    # ``user_permissions`` blob and mis-compare.
+    if axis.startswith(f"{_COMPOSITE_USER_PERMISSIONS_AXIS}:"):
+        return None
+
+    # Top-level first (wherever HB chooses to surface the axis), then nested
+    # under ``tenant``. ``ConfigCache.get`` reads the raw cached dict.
+    value = config_cache.get(axis, None) if hasattr(config_cache, "get") else None
+    if value is None and hasattr(config_cache, "get_tenant"):
+        tenant = config_cache.get_tenant() or {}
+        value = tenant.get(axis)
+    return None if value is None else str(value)
+
+
+def evaluate_version_drift(
+    supplied_headers: Mapping[str, str],
+    *,
+    axis_value_accessor: Callable[[str], Optional[str]],
+    header_axis_map: Optional[Mapping[str, str]] = None,
+    user_id: str = "",
+) -> Optional[VersionDriftError]:
+    """
+    Pure drift evaluation (no Request/app coupling — directly unit-testable).
+
+    Walks the configured header map in order; for every header PRESENT in
+    ``supplied_headers`` it resolves the axis and, when the axis has a KNOWN
+    authoritative value, compares supplied-vs-expected. Returns a
+    :class:`VersionDriftError` for the first mismatch, else ``None``.
+
+    Mirror of SBS ``_drift_response_if_needed`` (sans the forced-drift demo
+    primer, which is SBS-only test scaffolding).
+
+    * ``axis_value_accessor(axis)`` returns the authoritative value or ``None``
+      (skip — unknown/untracked axis; NEEDS-HB).
+    * The composite ``user_permissions`` header is expanded to
+      ``user_permissions:<user_id>`` using ``user_id`` (the caller's JWT-derived
+      identity). Without a user id the composite axis is skipped — a non-user
+      caller has no per-user permissions axis.
+
+    Iteration is over ``header_axis_map`` (deterministic insertion order) rather
+    than ``supplied_headers`` so "first mismatch wins" is stable regardless of
+    request header ordering.
+    """
+    mapping = header_axis_map if header_axis_map is not None else DEFAULT_HEADER_AXIS_MAP
+    # Normalise supplied header keys to lowercase once for case-insensitive lookup.
+    supplied_lower = {str(k).lower(): str(v) for k, v in supplied_headers.items()}
+
+    for header_name, axis in mapping.items():
+        if header_name.lower() not in supplied_lower:
+            continue
+        got = supplied_lower[header_name.lower()]
+
+        if axis == _COMPOSITE_USER_PERMISSIONS_AXIS:
+            if not user_id:
+                # No JWT-derived user identity → can't form the composite axis.
+                continue
+            axis = f"{_COMPOSITE_USER_PERMISSIONS_AXIS}:{user_id}"
+
+        expected = axis_value_accessor(axis)
+        if expected is None:
+            # Unknown / untracked authoritative value → cannot drift (NEEDS-HB).
+            continue
+
+        if got != str(expected):
+            return VersionDriftError(axis=axis, expected=str(expected), got=got)
+    return None
+
+
+def _supplied_axis_headers(
+    request: Request,
+    header_axis_map: Mapping[str, str],
+) -> Dict[str, str]:
+    """Collect the raw axis headers present on the request (lowercase keys)."""
+    out: Dict[str, str] = {}
+    for header_name in header_axis_map:
+        value = request.headers.get(header_name)
+        if value is not None:
+            out[header_name] = value
+    return out
+
+
+def make_version_drift_guard(
+    *,
+    header_axis_map: Optional[Mapping[str, str]] = None,
+    axis_value_accessor: Optional[
+        Callable[[Any, str], Optional[str]]
+    ] = None,
+):
+    """
+    Build a ``version_drift_guard`` dependency, optionally with a re-pinned
+    header map or a custom authoritative-value accessor.
+
+    The returned dependency depends on :func:`authenticate_request` so it
+    receives the resolved :class:`CallerContext`. FastAPI dedupes the shared
+    ``authenticate_request`` dependency, so on ``/api/ingest`` (where the
+    handler also depends on it) auth resolves exactly once and the SAME context
+    is shared. The user-permissions axis derives ``<user_id>`` from
+    ``ctx.identifier`` (JWT-derived) for the user actor only.
+
+    ``axis_value_accessor`` signature is ``(config_cache, axis) -> str | None``;
+    defaults to :func:`_config_cache_axis_value`. This is the seam HB-S3/S4
+    plugs into once it feeds the extra axes — no call-site change required.
+    """
+    resolved_map = header_axis_map if header_axis_map is not None else DEFAULT_HEADER_AXIS_MAP
+    resolved_accessor = axis_value_accessor or _config_cache_axis_value
+
+    async def _guard(
+        request: Request,
+        ctx: CallerContext = Depends(authenticate_request),
+    ) -> None:
+        supplied = _supplied_axis_headers(request, resolved_map)
+        if not supplied:
+            # No version axes on the request → nothing to check, pass through.
+            return
+
+        config_cache = getattr(request.app.state, "config_cache", None)
+
+        # Composite ``user_permissions`` axis: the user id is the caller's
+        # JWT-derived identity. Only the user actor has one; HMAC/ERP and
+        # service callers have no per-user permissions axis (→ skipped).
+        user_id = ctx.identifier if (ctx is not None and ctx.is_user) else ""
+
+        def _accessor(axis: str) -> Optional[str]:
+            return resolved_accessor(config_cache, axis)
+
+        drift = evaluate_version_drift(
+            supplied,
+            axis_value_accessor=_accessor,
+            header_axis_map=resolved_map,
+            user_id=user_id,
+        )
+        if drift is not None:
+            # Raise BEFORE the handler runs — request is NOT forwarded, so no
+            # backend side effects (§B-Drift "no stale-policy commit").
+            raise drift
+
+    return _guard
+
+
+# Default guard instance for ordinary call sites. Mount as a route dependency:
+#   @router.post("/api/ingest", dependencies=[Depends(version_drift_guard)])
+# or add it to the route's ``dependencies=[...]`` list in the include.
+version_drift_guard = make_version_drift_guard()

--- a/services/relay/tests/api/test_version_drift.py
+++ b/services/relay/tests/api/test_version_drift.py
@@ -1,0 +1,568 @@
+"""
+Tests for the §B-Drift / §B-VersionAxes version-drift gateway guard.
+
+Covered:
+  * Exact 409 body per axis on a supplied-axis mismatch.
+  * Pass-through when axes match.
+  * Pass-through when axis headers are absent.
+  * Pass-through when the authoritative value is unknown (NEEDS-HB skip).
+  * The five canonical ``X-Helium-*`` headers map to the right axes.
+  * The guard runs BEFORE the handler — a drifted request produces NO handler
+    side effect and is NOT forwarded.
+  * Composite ``user_permissions:<uid>`` axis with the uid derived from the
+    JWT-resolved CallerContext (not a sibling header); skipped for non-user
+    callers.
+  * ``policy_revision`` read from ConfigCache (top-level + nested under tenant).
+  * Wiring: ``/api/ingest`` and ``/api/finalize`` carry the guard; the app
+    registers the VersionDriftError handler.
+
+The guard is exercised both as a pure function (``evaluate_version_drift``) and
+through a real FastAPI app with the guard mounted on a sentinel route. The app
+tests override ``authenticate_request`` with a fixed CallerContext so we can
+prove ordering/no-side-effect (and the JWT-derived user id) without signing
+multipart-HMAC requests.
+"""
+
+import pytest
+from fastapi import Depends, FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+
+from src.api.caller_context import CallerContext
+from src.api.deps import authenticate_request
+from src.api.version_drift import (
+    DEFAULT_HEADER_AXIS_MAP,
+    VersionDriftError,
+    _config_cache_axis_value,
+    evaluate_version_drift,
+    make_version_drift_guard,
+    version_drift_error_handler,
+    version_drift_guard,
+)
+
+
+# ── Pure drift evaluation ──────────────────────────────────────────────────
+
+
+def _accessor_for(values: dict):
+    def _acc(axis: str):
+        return values.get(axis)
+
+    return _acc
+
+
+class TestEvaluateVersionDrift:
+    def test_match_passes(self):
+        result = evaluate_version_drift(
+            {"X-Helium-Policy-Revision": "v5"},
+            axis_value_accessor=_accessor_for({"policy_revision": "v5"}),
+        )
+        assert result is None
+
+    def test_absent_headers_pass(self):
+        result = evaluate_version_drift(
+            {},
+            axis_value_accessor=_accessor_for({"policy_revision": "v5"}),
+        )
+        assert result is None
+
+    def test_mismatch_raises_with_exact_fields(self):
+        result = evaluate_version_drift(
+            {"X-Helium-Policy-Revision": "v4"},
+            axis_value_accessor=_accessor_for({"policy_revision": "v5"}),
+        )
+        assert isinstance(result, VersionDriftError)
+        assert result.axis == "policy_revision"
+        assert result.expected == "v5"
+        assert result.got == "v4"
+        assert result.to_body() == {
+            "code": "version_drift",
+            "axis": "policy_revision",
+            "expected": "v5",
+            "got": "v4",
+        }
+
+    def test_header_lookup_is_case_insensitive(self):
+        # lowercased wire header still resolves to the policy axis
+        result = evaluate_version_drift(
+            {"x-helium-policy-revision": "v4"},
+            axis_value_accessor=_accessor_for({"policy_revision": "v5"}),
+        )
+        assert result is not None
+        assert result.axis == "policy_revision"
+
+    def test_unknown_authoritative_value_is_skipped(self):
+        # license supplied but the accessor returns None → NEEDS-HB skip
+        result = evaluate_version_drift(
+            {"X-Helium-License-State": "lic-9"},
+            axis_value_accessor=_accessor_for({}),  # everything unknown
+        )
+        assert result is None
+
+    @pytest.mark.parametrize(
+        "header,axis,expected,got",
+        [
+            ("X-Helium-Policy-Revision", "policy_revision", "p2", "p1"),
+            ("X-Helium-License-State", "license_state_id", "lic-2", "lic-1"),
+            ("X-Helium-Usage-State", "usage_state_id", "use-2", "use-1"),
+            (
+                "X-Helium-Auth-Policy-Revision",
+                "auth_policy_revision",
+                "auth-2",
+                "auth-1",
+            ),
+        ],
+    )
+    def test_each_first_class_axis_drifts_with_exact_body(
+        self, header, axis, expected, got
+    ):
+        result = evaluate_version_drift(
+            {header: got},
+            axis_value_accessor=_accessor_for({axis: expected}),
+        )
+        assert result is not None
+        assert result.to_body() == {
+            "code": "version_drift",
+            "axis": axis,
+            "expected": expected,
+            "got": got,
+        }
+
+    def test_composite_user_permissions_drift(self):
+        result = evaluate_version_drift(
+            {"X-Helium-User-Permissions-Revision": "perm-1"},
+            axis_value_accessor=_accessor_for({"user_permissions:u-7": "perm-2"}),
+            user_id="u-7",
+        )
+        assert result is not None
+        assert result.axis == "user_permissions:u-7"
+        assert result.expected == "perm-2"
+        assert result.got == "perm-1"
+
+    def test_composite_user_permissions_without_user_id_is_skipped(self):
+        # No JWT-derived user id (e.g. HMAC/ERP caller) → composite axis skipped.
+        result = evaluate_version_drift(
+            {"X-Helium-User-Permissions-Revision": "perm-1"},
+            axis_value_accessor=_accessor_for({"user_permissions:u-7": "perm-2"}),
+            user_id="",
+        )
+        assert result is None
+
+    def test_first_mismatch_wins_in_map_order(self):
+        # Both drift; policy is iterated first in DEFAULT_HEADER_AXIS_MAP order,
+        # regardless of supplied-header insertion order.
+        result = evaluate_version_drift(
+            {
+                "X-Helium-License-State": "lic-1",
+                "X-Helium-Policy-Revision": "p1",
+            },
+            axis_value_accessor=_accessor_for(
+                {"policy_revision": "p2", "license_state_id": "lic-2"}
+            ),
+        )
+        assert result is not None
+        assert result.axis == "policy_revision"
+
+
+# ── Canonical header map shape ─────────────────────────────────────────────
+
+
+class TestCanonicalHeaderMap:
+    def test_default_map_has_exactly_five_axes(self):
+        assert DEFAULT_HEADER_AXIS_MAP == {
+            "x-helium-policy-revision": "policy_revision",
+            "x-helium-license-state": "license_state_id",
+            "x-helium-usage-state": "usage_state_id",
+            "x-helium-auth-policy-revision": "auth_policy_revision",
+            "x-helium-user-permissions-revision": "user_permissions",
+        }
+
+    def test_no_legacy_or_colon_named_headers(self):
+        # SBS bare-name / colon-named scheme must NOT leak into the wire map.
+        for key in DEFAULT_HEADER_AXIS_MAP:
+            assert key.startswith("x-helium-")
+            assert ":" not in key
+
+
+# ── Guard dependency through a real app (ordering / no side effect) ────────
+
+
+class _Spy:
+    """Records whether the protected handler body ran (a 'side effect')."""
+
+    def __init__(self):
+        self.handler_ran = False
+
+
+def _make_guarded_app(
+    authoritative: dict,
+    spy: _Spy,
+    *,
+    ctx: CallerContext,
+) -> FastAPI:
+    """
+    Build a minimal app with the REAL guard mounted on a sentinel POST route,
+    backed by an in-memory authoritative-value accessor. ``authenticate_request``
+    is overridden to return ``ctx`` so the guard sees a fixed JWT-derived
+    identity without HMAC/JWT plumbing.
+    """
+    guard = make_version_drift_guard(
+        axis_value_accessor=lambda _cache, axis: authoritative.get(axis)
+    )
+    app = FastAPI()
+    app.add_exception_handler(VersionDriftError, version_drift_error_handler)
+
+    @app.post("/sentinel", dependencies=[Depends(guard)])
+    async def sentinel(request: Request):  # noqa: ANN201
+        spy.handler_ran = True
+        return {"ok": True}
+
+    app.dependency_overrides[authenticate_request] = lambda: ctx
+    return app
+
+
+_USER_CTX = CallerContext(
+    actor_type="user",
+    tenant_id="t-1",
+    identifier="u-7",
+    permissions=["*"],
+)
+_ERP_CTX = CallerContext(
+    actor_type="erp",
+    tenant_id="t-1",
+    identifier="api-key-xyz",
+    permissions=["blob.write"],
+)
+
+
+@pytest.fixture
+async def guarded_client_factory():
+    clients = []
+
+    async def _factory(
+        authoritative: dict,
+        spy: _Spy,
+        *,
+        ctx: CallerContext = _USER_CTX,
+    ) -> AsyncClient:
+        app = _make_guarded_app(authoritative, spy, ctx=ctx)
+        transport = ASGITransport(app=app)
+        client = AsyncClient(transport=transport, base_url="http://test")
+        clients.append(client)
+        return client
+
+    yield _factory
+    for c in clients:
+        await c.aclose()
+
+
+class TestGuardThroughApp:
+    @pytest.mark.asyncio
+    async def test_match_forwards_to_handler(self, guarded_client_factory):
+        spy = _Spy()
+        client = await guarded_client_factory({"policy_revision": "v5"}, spy)
+        resp = await client.post(
+            "/sentinel", headers={"X-Helium-Policy-Revision": "v5"}
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+        assert spy.handler_ran is True
+
+    @pytest.mark.asyncio
+    async def test_absent_axes_forward_to_handler(self, guarded_client_factory):
+        spy = _Spy()
+        client = await guarded_client_factory({"policy_revision": "v5"}, spy)
+        resp = await client.post("/sentinel")
+        assert resp.status_code == 200
+        assert spy.handler_ran is True
+
+    @pytest.mark.asyncio
+    async def test_drift_returns_exact_409_and_does_not_run_handler(
+        self, guarded_client_factory
+    ):
+        spy = _Spy()
+        client = await guarded_client_factory({"policy_revision": "v5"}, spy)
+        resp = await client.post(
+            "/sentinel", headers={"X-Helium-Policy-Revision": "v4"}
+        )
+        assert resp.status_code == 409
+        assert resp.json() == {
+            "code": "version_drift",
+            "axis": "policy_revision",
+            "expected": "v5",
+            "got": "v4",
+        }
+        # The decisive assertion: guard ran BEFORE the handler — no side effect,
+        # request NOT forwarded.
+        assert spy.handler_ran is False
+
+    @pytest.mark.asyncio
+    async def test_unknown_axis_value_forwards(self, guarded_client_factory):
+        # authoritative has nothing → license axis supplied but value unknown →
+        # skip (NEEDS-HB), request forwards.
+        spy = _Spy()
+        client = await guarded_client_factory({}, spy)
+        resp = await client.post(
+            "/sentinel", headers={"X-Helium-License-State": "lic-anything"}
+        )
+        assert resp.status_code == 200
+        assert spy.handler_ran is True
+
+    @pytest.mark.asyncio
+    async def test_composite_user_permissions_409_uses_jwt_user_id(
+        self, guarded_client_factory
+    ):
+        # ctx.identifier = "u-7" → axis becomes user_permissions:u-7
+        spy = _Spy()
+        client = await guarded_client_factory(
+            {"user_permissions:u-7": "perm-2"}, spy, ctx=_USER_CTX
+        )
+        resp = await client.post(
+            "/sentinel",
+            headers={"X-Helium-User-Permissions-Revision": "perm-1"},
+        )
+        assert resp.status_code == 409
+        assert resp.json() == {
+            "code": "version_drift",
+            "axis": "user_permissions:u-7",
+            "expected": "perm-2",
+            "got": "perm-1",
+        }
+        assert spy.handler_ran is False
+
+    @pytest.mark.asyncio
+    async def test_composite_user_permissions_skipped_for_non_user_caller(
+        self, guarded_client_factory
+    ):
+        # ERP caller has no JWT user identity → composite axis is skipped even
+        # though the header is supplied → request forwards.
+        spy = _Spy()
+        client = await guarded_client_factory(
+            {"user_permissions:api-key-xyz": "perm-2"}, spy, ctx=_ERP_CTX
+        )
+        resp = await client.post(
+            "/sentinel",
+            headers={"X-Helium-User-Permissions-Revision": "perm-1"},
+        )
+        assert resp.status_code == 200
+        assert spy.handler_ran is True
+
+
+# ── policy_revision read from ConfigCache ──────────────────────────────────
+
+
+class TestConfigCacheAccessor:
+    def test_policy_revision_read_top_level(self):
+        from src.config_cache import ConfigCache
+
+        cache = ConfigCache(heartbeat_client=None)
+        cache._config = {"policy_revision": "rev-top"}
+        assert _config_cache_axis_value(cache, "policy_revision") == "rev-top"
+
+    def test_policy_revision_read_nested_under_tenant(self):
+        from src.config_cache import ConfigCache
+
+        cache = ConfigCache(heartbeat_client=None)
+        cache._config = {"tenant": {"policy_revision": "rev-nested"}}
+        assert _config_cache_axis_value(cache, "policy_revision") == "rev-nested"
+
+    def test_untracked_axes_return_none_today(self):
+        # NEEDS-HB: these are not in the cached config shape yet.
+        from src.config_cache import ConfigCache
+
+        cache = ConfigCache(heartbeat_client=None)
+        cache._config = {"policy_revision": "rev-top"}
+        for axis in (
+            "license_state_id",
+            "usage_state_id",
+            "auth_policy_revision",
+            "user_permissions:u-1",
+        ):
+            assert _config_cache_axis_value(cache, axis) is None
+
+    def test_axis_lights_up_when_hb_feeds_it(self):
+        # Forward-compat: once HB surfaces e.g. usage_state_id in the cached
+        # config, the generic accessor resolves it with no code change.
+        from src.config_cache import ConfigCache
+
+        cache = ConfigCache(heartbeat_client=None)
+        cache._config = {"usage_state_id": "use-42"}
+        assert _config_cache_axis_value(cache, "usage_state_id") == "use-42"
+
+    def test_composite_user_permissions_never_read_from_top_level(self):
+        # Even if a stray top-level ``user_permissions`` blob exists, the
+        # composite axis must NOT mis-resolve against it (needs per-user fabric).
+        from src.config_cache import ConfigCache
+
+        cache = ConfigCache(heartbeat_client=None)
+        cache._config = {"user_permissions": "should-be-ignored"}
+        assert _config_cache_axis_value(cache, "user_permissions:u-1") is None
+
+    def test_none_cache_returns_none(self):
+        assert _config_cache_axis_value(None, "policy_revision") is None
+
+
+# ── /api/ingest + /api/finalize wiring + app handler registration ──────────
+
+
+class TestRouteWiringAndAppHandler:
+    def test_ingest_route_carries_version_drift_guard(self):
+        from src.api.routes.ingest import router
+
+        ingest_routes = [
+            r for r in router.routes if getattr(r, "path", "") == "/api/ingest"
+        ]
+        assert ingest_routes, "/api/ingest route not found"
+        dep_calls = [d.dependency for d in ingest_routes[0].dependencies]
+        assert version_drift_guard in dep_calls, (
+            "version_drift_guard not registered as an /api/ingest route dependency"
+        )
+
+    def test_finalize_route_carries_version_drift_guard(self):
+        from src.api.routes.finalize import router
+
+        finalize_routes = [
+            r for r in router.routes if getattr(r, "path", "") == "/api/finalize"
+        ]
+        assert finalize_routes, "/api/finalize route not found"
+        dep_calls = [d.dependency for d in finalize_routes[0].dependencies]
+        assert version_drift_guard in dep_calls, (
+            "version_drift_guard not registered as an /api/finalize route dependency"
+        )
+
+    def test_app_registers_version_drift_handler(self):
+        from src.api.app import create_app
+        from src.config import RelayConfig
+
+        cfg = RelayConfig(
+            host="127.0.0.1",
+            port=8082,
+            instance_id="relay-test",
+            require_encryption=False,
+            heartbeat_api_key="test-relay-key",
+            heartbeat_s2s_signing_key="0123456789abcdef" * 4,
+        )
+        app = create_app(config=cfg, api_key_secrets={"k": "s"})
+        assert VersionDriftError in app.exception_handlers
+
+
+# ── End-to-end through the REAL /api/finalize route (HMAC-signed) ──────────
+#
+# Proves the guard fires through a real sensitive mutating route + the app's
+# exception handler, that a stale axis blocks the request BEFORE the handler
+# (no relay.finalize.accepted lifecycle event emitted = not forwarded), and that
+# a matching axis passes through to a 202. The finalize route is chosen because
+# its JSON body is HMAC-signable (unlike multipart ingest).
+
+
+class TestFinalizeRouteDriftEndToEnd:
+    TEST_API_KEY = "test-key-001"
+    TEST_SECRET = "secret-001"
+
+    def _config(self):
+        from src.config import RelayConfig
+
+        return RelayConfig(
+            host="127.0.0.1",
+            port=8082,
+            instance_id="relay-test",
+            require_encryption=False,
+            max_files=5,
+            max_file_size_mb=10.0,
+            max_total_size_mb=30.0,
+            allowed_extensions=(".pdf", ".xml", ".json", ".csv", ".xlsx"),
+            internal_service_token="test-internal-token",
+            heartbeat_api_key="test-relay-key",
+            heartbeat_s2s_signing_key="0123456789abcdef" * 4,
+        )
+
+    def _hmac_headers(self, body: bytes, extra: dict | None = None) -> dict:
+        from datetime import datetime, timezone
+
+        from src.core.auth import compute_signature
+
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        sig = compute_signature(self.TEST_API_KEY, ts, body, self.TEST_SECRET)
+        headers = {
+            "X-API-Key": self.TEST_API_KEY,
+            "X-Timestamp": ts,
+            "X-Signature": sig,
+            "Content-Type": "application/json",
+        }
+        if extra:
+            headers.update(extra)
+        return headers
+
+    @pytest.mark.asyncio
+    async def test_stale_policy_axis_blocks_finalize_409_no_event(self):
+        import json
+
+        from asgi_lifespan import LifespanManager
+
+        from src.api.app import create_app
+        from src.services.finalize import FinalizeService
+        from src.services.lifecycle import RecordingLifecyclePublisher
+
+        app = create_app(
+            config=self._config(), api_key_secrets={self.TEST_API_KEY: self.TEST_SECRET}
+        )
+        async with LifespanManager(app):
+            # Seed Relay's authoritative policy_revision + a recording publisher
+            # so we can prove the lifecycle event is NOT emitted on drift.
+            app.state.config_cache._config["policy_revision"] = "server-rev-9"
+            recorder = RecordingLifecyclePublisher()
+            app.state.lifecycle_publisher = recorder
+            app.state.finalize_service = FinalizeService(app.state.core, recorder)
+
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as c:
+                body = json.dumps(
+                    {"ref": "sha256:drifted", "trace_id": "018f-drift-1"}
+                ).encode("utf-8")
+                headers = self._hmac_headers(
+                    body, extra={"X-Helium-Policy-Revision": "client-rev-8"}
+                )
+                resp = await c.post("/api/finalize", content=body, headers=headers)
+
+        assert resp.status_code == 409, resp.text
+        assert resp.json() == {
+            "code": "version_drift",
+            "axis": "policy_revision",
+            "expected": "server-rev-9",
+            "got": "client-rev-8",
+        }
+        # Not forwarded: the finalize handler never ran, so no lifecycle event.
+        assert recorder.events == []
+
+    @pytest.mark.asyncio
+    async def test_matching_policy_axis_passes_finalize_202(self):
+        import json
+
+        from asgi_lifespan import LifespanManager
+
+        from src.api.app import create_app
+        from src.services.finalize import FinalizeService
+        from src.services.lifecycle import RecordingLifecyclePublisher
+
+        app = create_app(
+            config=self._config(), api_key_secrets={self.TEST_API_KEY: self.TEST_SECRET}
+        )
+        async with LifespanManager(app):
+            app.state.config_cache._config["policy_revision"] = "server-rev-9"
+            recorder = RecordingLifecyclePublisher()
+            app.state.lifecycle_publisher = recorder
+            app.state.finalize_service = FinalizeService(app.state.core, recorder)
+
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as c:
+                body = json.dumps(
+                    {"ref": "sha256:fresh", "trace_id": "018f-fresh-1"}
+                ).encode("utf-8")
+                headers = self._hmac_headers(
+                    body, extra={"X-Helium-Policy-Revision": "server-rev-9"}
+                )
+                resp = await c.post("/api/finalize", content=body, headers=headers)
+
+        assert resp.status_code == 202, resp.text
+        assert resp.json()["trace_id"] == "018f-fresh-1"
+        # Forwarded: the finalize handler ran → one lifecycle event emitted.
+        assert len(recorder.events) == 1


### PR DESCRIPTION
## R-M3 §B-Drift — version-drift gateway (`X-Helium-*` five-axis)

Reusable `version_drift_guard` FastAPI dependency on **`/api/ingest` + `/api/finalize`**. Reads the five `X-Helium-*` version-axis headers, compares each **supplied** axis to Relay's authoritative current value (`app.state.config_cache`), returns **`409 {code:"version_drift", axis, expected, got}`** BEFORE the handler (request not forwarded — no backend side effects). Absent/unknown axes pass through.

**Canon (Q17 ratified — FIVE axes):** `X-Helium-Policy-Revision`→`policy_revision` · `X-Helium-License-State`→`license_state_id` · `X-Helium-Usage-State`→`usage_state_id` (ON) · `X-Helium-Auth-Policy-Revision`→`auth_policy_revision` · `X-Helium-User-Permissions-Revision`→`user_permissions` (composite; `<user_id>` derived server-side from the JWT). Configurable `DEFAULT_HEADER_AXIS_MAP`; no colon-named / bare-name SBS headers.

**Tests:** `tests/api/test_version_drift.py` — **31 passed** (incl. 2 HMAC-signed e2e finalize tests: drift → 409 with **no lifecycle event emitted**; matching axis → 202). **Seat verified full suite: 668 passed / 7 pre-existing failed** (the documented ingest_route ×2 / irn ×1 / qr ×3 / external ×1; no new regression).

**Cross-seat NEEDS (HB-S3/S4 fabric):** `config_cache` tracks only `policy_revision` today; the pluggable accessor returns `None` (→ axis skipped) for `license_state_id` / `usage_state_id` / `auth_policy_revision` / `user_permissions:<uid>` until HB feeds them — they light up with **zero code change**. HB to confirm the final `X-Helium-*` spellings (≤ cosmetic rename, absorbed in the map).

**Flags for ARCH:**
1. **`/api/finalize` double-auth:** the guard's `Depends(authenticate_request)` + finalize's in-handler auth resolve auth twice. Idempotent (HMAC recompute / cached introspect), proven harmless by the e2e 202 test, but a second introspect on the JWT path. Single-auth would need finalize to consume the guard-injected `ctx` (deferred — out of R-M3 scope).
2. **`usage_state_id` 409-drift vs SBS 429 quota:** wired as a first-class 409-drift axis per the "ON" canon, but the SBS models usage via a separate `quota_refused` (429) path — confirm 409-drift and 429-quota are intended as **distinct** gates.
3. Composite `user_permissions` axis is dormant until HB ships the per-user revision fabric + the JWT path is exercised.

Base `b2afaa6` (post #20/#23/#24). Branch `feat/relay-cssv1-rm3-version-drift-v2` @ `e1a217d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
