### PR TITLE
feat(relay): R-M4 B-RelayArtifactFetch — POST /api/artifacts/fetch (X-Relay-Artifact-*)

### DIFF
--- a/services/relay/src/api/app.py
+++ b/services/relay/src/api/app.py
@@ -36,6 +36,7 @@ from ..services.finalize import FinalizeService
 from ..services.ingestion import IngestionService
 from ..services.lifecycle import CoreLifecyclePublisher
 from .middleware import BodyCacheMiddleware, TraceIDMiddleware, relay_error_handler
+from .routes.artifacts import router as artifacts_router
 from .routes.duplicate import router as duplicate_router
 from .routes.finalize import router as finalize_router
 from .routes.health import router as health_router
@@ -220,5 +221,6 @@ def create_app(
     app.include_router(finalize_router)
     app.include_router(internal_router)
     app.include_router(duplicate_router)
+    app.include_router(artifacts_router)
 
     return app

--- a/services/relay/src/api/routes/artifacts.py
+++ b/services/relay/src/api/routes/artifacts.py
@@ -1,0 +1,294 @@
+"""
+POST /api/artifacts/fetch — Scout-callable artifact bytes / lifecycle JSON
+(R-M4 / §B-RelayArtifactFetch).
+
+Implements CLAUDE.md "Backend Debt Notes" §B-RelayArtifactFetch +
+READER_RELAY_INTEGRATION_DEBT_MAP_2026_06_12.md L139-201.
+
+VERB_DELTA (the single load-bearing delta for this chip): the SBS sketch
+``relay_fetch_artifact`` (relay.py:1030) docstrings ``GET /api/relay/artifacts/
+<ref>`` with the ``artifact_ref`` IN THE PATH. The real Relay route is
+**POST-body**: ``POST /api/artifacts/fetch { artifact_ref, artifact_type }``.
+``artifact_ref`` is effectively a *bearer capability* for raw signed-PDF / HLX /
+FIRS bytes — it MUST NEVER appear in a URL, querystring, proxy log, or referrer.
+So it travels in the POST body only (debt-map L193-200). There is deliberately
+NO GET variant.
+
+Bytes-vs-JSON:
+    - HARD artifacts → raw **bytes** to Scout, ``Content-Type`` per kind, sourced
+      from HeartBeat blob storage (``HeartBeatClient.fetch_blob``).
+    - LIFECYCLE artifacts → raw **JSON** to Scout, sourced from Core
+      (``CoreClient.fetch_lifecycle_artifact``). Reader never sees this raw JSON;
+      Scout reduces it to display-safe fields (``raw_bytes_sent`` stays false).
+    - A miss → HTTP 404 ``{"code": "ARTIFACT_NOT_FOUND", "artifact_ref": <ref>}``
+      (EXACT contract body; see ``ArtifactNotFoundError.to_dict``).
+
+Kind signalling: the Scout production adapter ``ScoutRelayArtifactFetchAdapter``
+(scout.py:567-590) sends an explicit ``artifact_type`` alongside ``artifact_ref``,
+so the route uses that as the primary discriminator, with a fallback inference
+from the ref prefix (``manifest-`` ⇒ a lifecycle JSON manifest) when
+``artifact_type`` is absent. (ARCH Open Q (b) — request-signalled vs
+Relay-inferred-from-stored-kind, and the closed kind enumeration; this chip
+PROPOSES the enum in its handoff report. Until ARCH rules, request-signalled
+with prefix fallback is the conservative choice.)
+
+CANON — response headers MUST be ``X-Relay-Artifact-*``; NEVER ``X-SBS-*`` (the
+SBS-branded ``X-SBS-Relay-Artifact`` / ``X-SBS-Artifact-Ref`` /
+``X-SBS-Artifact-Version`` / ``X-SBS-Durable-Invoice-Data`` headers in
+relay.py:1054-1059 are simulator-only and must not ship). The route emits:
+    - ``X-Relay-Artifact: true``
+    - ``X-Relay-Artifact-Ref: <artifact_ref>``  (echo; the request carried it)
+    - ``X-Relay-Artifact-Kind: <hard|lifecycle>``
+    - ``X-Relay-Artifact-ETag: sha256:<digest>``  (over the returned body)
+and, for QR blobs, ``X-Relay-Durable-Invoice-Data: qr_bytes``.
+
+Auth: the existing combined dispatcher ``authenticate_request`` (HMAC / Bearer
+JWT / service creds), resolved inside the handler (mirrors /api/finalize) so the
+SAME dispatcher /api/ingest uses runs, and the cached raw body is read for HMAC
+before the JSON is parsed.
+"""
+
+import hashlib
+import json
+import logging
+from typing import Optional, Tuple
+
+from fastapi import APIRouter, Request, Response
+from fastapi.responses import JSONResponse
+
+from ..caller_context import CallerContext
+from ..deps import authenticate_request
+from ...errors import ArtifactNotFoundError, ValidationFailedError
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# ── Kind classification (§B-RelayArtifactFetch) ──────────────────────────────
+#
+# Closed kind enum (PROPOSED — ARCH Open Q (b)). Derived from the SBS
+# ``_blob_payload`` kind→mime map (scout_backend_simulator_core.py:710-750) +
+# the debt-map observed list (L216-218) + the concrete ``artifact_type`` values
+# the Scout adapter actually sends (scout.py:4060 ``approval_lifecycle``,
+# scout.py:7981/8193 ``backend_copy``).
+#
+# HARD artifacts → bytes, with the Content-Type to serve per kind.
+_HARD_ARTIFACT_CONTENT_TYPES = {
+    # PDFs (the dominant hard artifact). ``backend_copy`` is the Scout adapter's
+    # name for an approver's backend PDF copy (scout.py:7981/8193).
+    "signed_pdf": "application/pdf",
+    "fixed_pdf": "application/pdf",
+    "original_pdf": "application/pdf",
+    "backend_pdf": "application/pdf",
+    "backend_copy": "application/pdf",
+    # Durable invoice QR payload bytes (NOT a generated QR-stamped PDF).
+    "qr_invoice": "application/vnd.helium.invoice-qr+json",
+    "qr_blob": "application/vnd.helium.invoice-qr+json",
+    # Raw detached signature bytes.
+    "signature": "application/octet-stream",
+}
+
+# Kinds whose Content-Type is the QR-invoice media type (used to add the
+# ``X-Relay-Durable-Invoice-Data`` marker, mirroring SBS relay.py:1058-1059).
+_QR_INVOICE_CONTENT_TYPE = "application/vnd.helium.invoice-qr+json"
+
+# LIFECYCLE artifacts → raw JSON (Core-owned).
+_LIFECYCLE_ARTIFACT_KINDS = frozenset(
+    {
+        "hlx",
+        "firs_returned_artifact",
+        "approval_lifecycle_json",
+        "approval_lifecycle",  # Scout adapter's spelling (scout.py:4060)
+        "manifest",
+    }
+)
+
+# Default Content-Type for a hard artifact whose kind is known-hard but not in
+# the explicit map (defensive; PDFs are the dominant hard artifact).
+_DEFAULT_HARD_CONTENT_TYPE = "application/pdf"
+
+
+def classify_artifact(
+    *,
+    artifact_type: Optional[str],
+    artifact_ref: str,
+) -> Tuple[str, Optional[str]]:
+    """Resolve ``(kind_class, content_type)`` for an artifact request.
+
+    ``kind_class`` is one of ``"lifecycle"`` (→ JSON) or ``"hard"`` (→ bytes).
+    ``content_type`` is the MIME to serve for hard artifacts, or ``None`` for
+    lifecycle (the JSON response sets its own).
+
+    Signalling priority (ARCH Open Q (b) — conservative default):
+        1. explicit ``artifact_type`` (what the Scout adapter sends);
+        2. fallback inference from the ref prefix (``manifest-`` ⇒ lifecycle
+           manifest), matching SBS ``relay_fetch_artifact`` relay.py:1035;
+        3. final fallback ⇒ hard/PDF (the dominant hard artifact).
+    """
+    kind = (artifact_type or "").strip().lower()
+
+    if kind:
+        if kind in _LIFECYCLE_ARTIFACT_KINDS:
+            return "lifecycle", None
+        if kind in _HARD_ARTIFACT_CONTENT_TYPES:
+            return "hard", _HARD_ARTIFACT_CONTENT_TYPES[kind]
+        # Unknown explicit kind — fall through to prefix inference, then to the
+        # hard/PDF default. We never *guess* JSON for an unknown kind (serving
+        # opaque bytes is safe; mislabelling bytes as JSON corrupts them).
+
+    # Fallback inference from the ref prefix (SBS parity).
+    ref = (artifact_ref or "").strip()
+    if ref.startswith("manifest-"):
+        return "lifecycle", None
+
+    return "hard", _DEFAULT_HARD_CONTENT_TYPE
+
+
+def _etag_for(body: bytes) -> str:
+    """SBS-mirrored ETag value: ``sha256:<hexdigest>`` over the body
+    (relay.py:1057 ``_artifact_etag``)."""
+    return f"sha256:{hashlib.sha256(body).hexdigest()}"
+
+
+async def _read_fetch_body(request: Request) -> dict:
+    """Read + parse the artifact-fetch JSON body from the cached raw body.
+
+    ``BodyCacheMiddleware`` stashes the raw bytes in ``request.state.raw_body``
+    (so HMAC auth and this handler read the SAME body — VERB_DELTA: the
+    ``artifact_ref`` is body-sourced, never path-sourced). Falls back to
+    ``request.body()`` if the cache is absent (e.g. direct unit calls).
+    """
+    raw = getattr(request.state, "raw_body", None)
+    if raw is None:
+        raw = await request.body()
+    if not raw:
+        raise ValidationFailedError(
+            message=(
+                "artifact fetch requires a JSON body with 'artifact_ref' "
+                "(and optionally 'artifact_type')."
+            ),
+        )
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise ValidationFailedError(
+            message=f"Invalid artifact-fetch JSON body: {exc}",
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise ValidationFailedError(
+            message="artifact-fetch body must be a JSON object.",
+        )
+    return parsed
+
+
+@router.post(
+    "/api/artifacts/fetch",
+    summary="Fetch artifact bytes (hard) or lifecycle JSON by artifact_ref (POST-body)",
+    responses={
+        200: {"description": "Artifact bytes (hard) or lifecycle JSON"},
+        400: {"description": "Invalid / missing JSON body"},
+        401: {"description": "Authentication failed"},
+        404: {"description": "Artifact not found (ARTIFACT_NOT_FOUND)"},
+    },
+)
+async def fetch_artifact(request: Request) -> Response:
+    """Fetch one artifact by reference — bytes for hard kinds, JSON for lifecycle.
+
+    Auth is enforced via the shared ``authenticate_request`` dispatcher (HMAC /
+    service-creds / user-JWT), identical to every other sensitive Relay route.
+    Resolved here (not as a ``Depends`` default) so the SAME dispatcher
+    /api/ingest uses runs and the cached raw body is read for HMAC BEFORE the
+    JSON is parsed. ``ctx`` is intentionally NOT a handler parameter so FastAPI
+    does not try to validate ``CallerContext`` as a request body.
+    """
+    ctx: CallerContext = await authenticate_request(request)
+
+    trace_id = ctx.trace_id or getattr(request.state, "trace_id", "")
+    body = await _read_fetch_body(request)
+
+    artifact_ref = str(body.get("artifact_ref") or "").strip()
+    artifact_type = body.get("artifact_type")
+    if artifact_type is not None:
+        artifact_type = str(artifact_type).strip() or None
+
+    if not artifact_ref:
+        # An empty/absent ref can never resolve — treat as a miss with the
+        # contract body (the VERB_DELTA forbids a path ref, so there is no
+        # other place it could have come from).
+        raise ArtifactNotFoundError(artifact_ref="")
+
+    kind_class, content_type = classify_artifact(
+        artifact_type=artifact_type,
+        artifact_ref=artifact_ref,
+    )
+
+    # User JWT is forwarded downstream for attribution; HMAC/service paths use
+    # Relay's own service credentials (HMAC s2s) to talk to HB/Core.
+    jwt_token: Optional[str] = None
+    if ctx.is_user:
+        auth_header = request.headers.get("authorization", "")
+        if auth_header.lower().startswith("bearer "):
+            jwt_token = auth_header[7:].strip()
+
+    logger.info(
+        "[%s] POST /api/artifacts/fetch — kind_class=%s artifact_type=%s "
+        "actor=%s tenant=%s jwt=%s",
+        trace_id,
+        kind_class,
+        artifact_type or "none",
+        ctx.actor_type,
+        ctx.tenant_id,
+        "yes" if jwt_token else "no",
+    )
+
+    if kind_class == "lifecycle":
+        core = request.app.state.core
+        lifecycle_json = await core.fetch_lifecycle_artifact(
+            artifact_ref=artifact_ref,
+            artifact_type=artifact_type,
+        )
+        if not lifecycle_json:
+            raise ArtifactNotFoundError(artifact_ref=artifact_ref)
+        # Raw JSON to Scout only. ETag over the canonical JSON bytes so a Scout
+        # cache can dedupe identical lifecycle payloads.
+        raw = json.dumps(lifecycle_json, sort_keys=True).encode("utf-8")
+        return JSONResponse(
+            content=lifecycle_json,
+            headers={
+                "X-Relay-Artifact": "true",
+                "X-Relay-Artifact-Ref": artifact_ref,
+                "X-Relay-Artifact-Kind": "lifecycle",
+                "X-Relay-Artifact-ETag": _etag_for(raw),
+            },
+        )
+
+    # HARD artifact → bytes from HB blob storage.
+    heartbeat = request.app.state.heartbeat
+    blob = await heartbeat.fetch_blob(artifact_ref=artifact_ref, jwt_token=jwt_token)
+    if not blob or not blob.get("data"):
+        raise ArtifactNotFoundError(artifact_ref=artifact_ref)
+
+    data: bytes = blob["data"]
+    # Prefer the kind-derived Content-Type (contract: per-kind); fall back to
+    # whatever HB reported for the stored blob, then to PDF.
+    served_content_type = (
+        content_type or blob.get("content_type") or _DEFAULT_HARD_CONTENT_TYPE
+    )
+
+    headers = {
+        "X-Relay-Artifact": "true",
+        "X-Relay-Artifact-Ref": artifact_ref,
+        "X-Relay-Artifact-Kind": "hard",
+        "X-Relay-Artifact-ETag": _etag_for(data),
+    }
+    # QR-invoice durable-data marker (SBS parity, de-branded from
+    # ``X-SBS-Durable-Invoice-Data``).
+    if served_content_type == _QR_INVOICE_CONTENT_TYPE:
+        headers["X-Relay-Durable-Invoice-Data"] = "qr_bytes"
+
+    return Response(
+        content=data,
+        media_type=served_content_type,
+        headers=headers,
+    )

--- a/services/relay/src/clients/core.py
+++ b/services/relay/src/clients/core.py
@@ -263,3 +263,50 @@ class CoreClient(BaseClient):
             return {"accepted": True, "family": family, "trace_id": trace}
 
         return await self.call_with_retries(_publish)
+
+    async def fetch_lifecycle_artifact(
+        self,
+        artifact_ref: str,
+        artifact_type: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Fetch a LIFECYCLE artifact as raw JSON by reference (§B-RelayArtifactFetch).
+
+        BACKEND CONTRACT (CLAUDE.md "Backend Debt Notes" §B-RelayArtifactFetch +
+        debt-map L139-160): lifecycle artifacts (HLX, FIRS-returned artifact,
+        approval-lifecycle JSON, manifest) are owned by **Core**, not HB blob
+        storage. Relay's artifact-fetch route returns these as raw JSON to Scout
+        only (Reader never receives the raw JSON — Scout reduces it to
+        display-safe fields; ``raw_bytes_sent`` stays false to Reader).
+
+        NEEDS-CORE: Core must expose a **POST-body** lifecycle-JSON-by-ref
+        endpoint. ``artifact_ref`` is a bearer capability — it MUST NOT travel
+        in a URL (cf. the existing Core ``GET /api/invoices/<id>`` shape the
+        VERB_DELTA ruling flags for migration). Modelled here as
+        ``POST {core}/api/artifacts/lifecycle {artifact_ref, artifact_type}``
+        returning the JSON document. Phase-1 stub: returns ``None`` so the
+        route's miss path (ARTIFACT_NOT_FOUND) is the default until Core wires a
+        real store; route correctness is proven with this method MOCKED.
+
+        Args:
+            artifact_ref: Capability handle for the lifecycle artifact.
+            artifact_type: Optional explicit kind (hlx / firs_returned_artifact
+                / approval_lifecycle_json / manifest) forwarded to Core.
+
+        Returns:
+            The lifecycle JSON document (a dict) on a hit, or ``None`` on a miss
+            (the route maps ``None`` → ARTIFACT_NOT_FOUND).
+        """
+        async def _fetch():
+            # Phase 1 stub — no Core lifecycle store wired yet (NEEDS-CORE).
+            # Returns None so the route resolves to ARTIFACT_NOT_FOUND; tests
+            # mock this method to exercise the JSON hit path.
+            logger.debug(
+                "Core fetch_lifecycle_artifact (stub) — ref=%s type=%s",
+                artifact_ref[:16],
+                artifact_type or "(none)",
+                extra={"trace_id": self.trace_id},
+            )
+            return None
+
+        return await self.call_with_retries(_fetch)

--- a/services/relay/src/clients/heartbeat.py
+++ b/services/relay/src/clients/heartbeat.py
@@ -345,6 +345,97 @@ class HeartBeatClient(BaseClient):
 
         return await self.call_with_retries(_write)
 
+    # ── Blob Fetch (§B-RelayArtifactFetch) ─────────────────────────────────
+
+    async def fetch_blob(
+        self,
+        artifact_ref: str,
+        jwt_token: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Fetch raw blob bytes from HeartBeat blob storage by reference.
+
+        BACKEND CONTRACT (CLAUDE.md "Backend Debt Notes" §B-RelayArtifactFetch +
+        debt-map L159-160): HeartBeat owns blob storage; Relay's artifact-fetch
+        route is a thin authenticated proxy to HB blob bytes for HARD artifacts
+        (signed / fixed / original / backend PDF, QR blob, signature). Relay
+        calls this with its OWN HB *service* credentials (HMAC s2s) — the
+        original ERP/user only holds the Relay ingest key, not HB-service creds
+        (mirrors the ``downstream_auth_header`` model in ``deps._verify_hmac``).
+
+        NEEDS-HB: HB must expose a **POST-body** blob-fetch-by-ref endpoint.
+        ``artifact_ref`` is a bearer capability — it MUST NOT travel in a URL
+        (consistent with HB's own audit M-1 "content identifier must not appear
+        in URLs/logs", already applied to dedup/config). Modelled here as
+        ``POST /api/blobs/fetch {blob_ref}`` returning the raw bytes with a
+        ``Content-Type`` header. The path/field shape is PROVISIONAL until HB
+        confirms (cross-seat NEEDS-HB); the Relay route is proven correct with
+        this method MOCKED in tests.
+
+        Args:
+            artifact_ref: Capability handle for the stored blob.
+            jwt_token: Optional user JWT to forward for attribution.
+
+        Returns:
+            ``{"content_type": str, "data": bytes}`` on a hit, or ``None`` on a
+            404 / empty miss (the route maps ``None`` → ARTIFACT_NOT_FOUND). The
+            ``content_type`` is the HB-reported MIME of the stored blob; the
+            route prefers the per-KIND Content-Type but falls back to this.
+
+        Raises:
+            HeartBeatUnavailableError: If HeartBeat is unreachable.
+            TransientError: If HeartBeat returns 5xx.
+        """
+        path = "/api/blobs/fetch"
+        body_bytes = self._json_bytes({"blob_ref": artifact_ref})
+
+        async def _fetch():
+            http = self._get_http()
+            headers = self._s2s_headers(
+                method="POST",
+                path=path,
+                body_bytes=body_bytes,
+            )
+            # Forward the user JWT for attribution when present; HB s2s HMAC
+            # still authenticates the Relay→HB hop itself.
+            if jwt_token:
+                headers["Authorization"] = f"Bearer {jwt_token}"
+
+            self._calls.append(("fetch_blob", artifact_ref))
+
+            try:
+                resp = await http.post(
+                    path,
+                    content=body_bytes,
+                    headers=headers,
+                )
+            except httpx.ConnectError as e:
+                raise HeartBeatUnavailableError(
+                    message=f"Cannot connect to HeartBeat for blob fetch: {e}"
+                ) from e
+
+            # A 404 from HB is a normal miss, not an error — the route maps it
+            # to the ARTIFACT_NOT_FOUND contract body.
+            if resp.status_code == 404:
+                return None
+
+            self._raise_for_status(resp, "fetch_blob")
+
+            data = resp.content
+            if not data:
+                return None
+            content_type = (
+                resp.headers.get("content-type") or "application/octet-stream"
+            )
+            logger.debug(
+                f"HeartBeat fetch_blob — ref={artifact_ref[:12]}..., "
+                f"bytes={len(data)}, content_type={content_type}",
+                extra={"trace_id": self.trace_id},
+            )
+            return {"content_type": content_type, "data": data}
+
+        return await self.call_with_retries(_fetch)
+
     # ── Deduplication ──────────────────────────────────────────────────────
 
     async def check_duplicate(self, file_hash: str) -> Dict[str, Any]:

--- a/services/relay/src/errors.py
+++ b/services/relay/src/errors.py
@@ -295,6 +295,39 @@ class QueueNotFoundError(RelayError):
         )
 
 
+class ArtifactNotFoundError(RelayError):
+    """
+    Artifact referenced by ``artifact_ref`` is not resolvable (§B-RelayArtifactFetch).
+
+    Per CLAUDE.md "Backend Debt Notes" §B-RelayArtifactFetch + the debt-map
+    (READER_RELAY_INTEGRATION_DEBT_MAP_2026_06_12.md L155-157), a miss on the
+    artifact-fetch route returns HTTP 404 with the EXACT body
+    ``{"code": "ARTIFACT_NOT_FOUND", "artifact_ref": <ref>}`` — NO
+    ``status`` / ``error_code`` / ``message`` / ``details`` envelope. This
+    mirrors the SBS executable spec (``relay_fetch_artifact`` relay.py:1039/1052
+    + ``fetch_blob_from_sbs`` core.py:122). ``to_dict`` is overridden so the
+    global ``relay_error_handler`` emits that contract shape verbatim rather
+    than the generic Relay error envelope.
+
+    ``artifact_ref`` is a bearer-capability handle: it is echoed in the body
+    (the request already carried it) but MUST NOT be placed in a URL / path /
+    proxy log (VERB_DELTA, §B-RelayArtifactFetch). The miss path here is
+    body-only, consistent with that rule.
+    """
+
+    def __init__(self, artifact_ref: str):
+        super().__init__(
+            error_code="ARTIFACT_NOT_FOUND",
+            message="Artifact not found.",
+            status_code=404,
+        )
+        self.artifact_ref = artifact_ref
+
+    def to_dict(self) -> Dict[str, Any]:
+        # Contract body shape — intentionally NOT the generic Relay envelope.
+        return {"code": self.error_code, "artifact_ref": self.artifact_ref}
+
+
 # ── Duplicate (409) ───────────────────────────────────────────────────────
 
 

--- a/services/relay/tests/api/test_artifacts_route.py
+++ b/services/relay/tests/api/test_artifacts_route.py
@@ -1,0 +1,432 @@
+"""
+Tests for POST /api/artifacts/fetch — R-M4 / §B-RelayArtifactFetch.
+
+Coverage (per the chip brief):
+    - the route is **POST** with a JSON body; there is NO GET variant and
+      ``artifact_ref`` is read from the BODY, not the path (VERB_DELTA);
+    - HARD artifact kinds return raw **bytes** with the per-kind Content-Type;
+    - LIFECYCLE artifact kinds return raw **JSON** (sourced from Core);
+    - a miss returns 404 with the EXACT body
+      ``{"code": "ARTIFACT_NOT_FOUND", "artifact_ref": <ref>}``;
+    - auth is required (the shared dispatcher rejects a credential-less call);
+    - response carries ``X-Relay-Artifact-*`` headers and NO ``X-SBS-*`` headers
+      (CANON — the SBS-branded headers must not ship).
+
+Auth model mirrors test_finalize_route.py: HMAC over the EXACT JSON body bytes
+(the fetch call has no multipart, so the signature is computable). The route
+resolves ``authenticate_request`` INSIDE the handler (not via Depends), so
+``app.dependency_overrides`` would NOT intercept it — real HMAC is used instead.
+
+The HB/Core client methods are mocked on the live ``app.state`` instances after
+lifespan startup, so these tests prove the ROUTE is correct without a real HB
+blob store or Core lifecycle store (NEEDS-HB / NEEDS-CORE).
+"""
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+from asgi_lifespan import LifespanManager
+from httpx import AsyncClient, ASGITransport
+
+from src.api.app import create_app
+from src.api.routes.artifacts import classify_artifact
+from src.config import RelayConfig
+from src.core.auth import compute_signature
+
+
+TEST_API_KEY = "test-key-001"
+TEST_SECRET = "secret-001"
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def test_config():
+    return RelayConfig(
+        host="127.0.0.1",
+        port=8082,
+        instance_id="relay-test",
+        require_encryption=False,
+        max_files=5,
+        max_file_size_mb=10.0,
+        max_total_size_mb=30.0,
+        allowed_extensions=(".pdf", ".xml", ".json", ".csv", ".xlsx"),
+        internal_service_token="test-internal-token",
+        heartbeat_api_key="test-relay-key",
+        heartbeat_s2s_signing_key="0123456789abcdef" * 4,
+    )
+
+
+@pytest.fixture
+def test_secrets():
+    return {TEST_API_KEY: TEST_SECRET}
+
+
+@pytest.fixture
+async def app_and_client(test_config, test_secrets):
+    """App + ASGI client over real lifespan startup. Client methods are mocked
+    per-test on the live ``app.state.heartbeat`` / ``app.state.core``."""
+    app = create_app(config=test_config, api_key_secrets=test_secrets)
+    async with LifespanManager(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            yield app, c
+
+
+def _hmac_headers_for_body(body: bytes) -> dict:
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    sig = compute_signature(TEST_API_KEY, ts, body, TEST_SECRET)
+    return {
+        "X-API-Key": TEST_API_KEY,
+        "X-Timestamp": ts,
+        "X-Signature": sig,
+        "Content-Type": "application/json",
+    }
+
+
+def _post_args(payload: dict) -> tuple[bytes, dict]:
+    """Serialise the JSON body + build matching HMAC headers.
+
+    The EXACT bytes are passed as ``content=`` so the signed body equals the
+    wire body (httpx's ``json=`` would re-serialise and could differ).
+    """
+    body = json.dumps(payload).encode("utf-8")
+    return body, _hmac_headers_for_body(body)
+
+
+def _assert_no_sbs_headers(resp) -> None:
+    """CANON: no simulator-branded ``X-SBS-*`` header may appear."""
+    for name in resp.headers.keys():
+        assert not name.lower().startswith("x-sbs-"), f"leaked SBS header: {name}"
+
+
+# ── HARD artifact → bytes ─────────────────────────────────────────────────
+
+
+class TestHardArtifactBytes:
+    @pytest.mark.asyncio
+    async def test_signed_pdf_returns_pdf_bytes(self, app_and_client):
+        app, client = app_and_client
+        pdf_bytes = b"%PDF-1.4\nsigned artifact body\n%%EOF\n"
+
+        async def fake_fetch_blob(artifact_ref, jwt_token=None):
+            assert artifact_ref == "blob-signed-001"
+            return {"content_type": "application/pdf", "data": pdf_bytes}
+
+        app.state.heartbeat.fetch_blob = fake_fetch_blob
+
+        body, headers = _post_args(
+            {"artifact_ref": "blob-signed-001", "artifact_type": "signed_pdf"}
+        )
+        resp = await client.post("/api/artifacts/fetch", content=body, headers=headers)
+
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["content-type"] == "application/pdf"
+        assert resp.content == pdf_bytes
+        # X-Relay-Artifact-* headers present; NO X-SBS-*.
+        assert resp.headers["x-relay-artifact"] == "true"
+        assert resp.headers["x-relay-artifact-ref"] == "blob-signed-001"
+        assert resp.headers["x-relay-artifact-kind"] == "hard"
+        assert resp.headers["x-relay-artifact-etag"].startswith("sha256:")
+        _assert_no_sbs_headers(resp)
+
+    @pytest.mark.asyncio
+    async def test_qr_invoice_content_type_and_durable_marker(self, app_and_client):
+        app, client = app_and_client
+        qr_bytes = b'{"irn": "ABC-123", "qr": true}'
+
+        async def fake_fetch_blob(artifact_ref, jwt_token=None):
+            # HB may report octet-stream; the route serves the per-KIND type.
+            return {"content_type": "application/octet-stream", "data": qr_bytes}
+
+        app.state.heartbeat.fetch_blob = fake_fetch_blob
+
+        body, headers = _post_args(
+            {"artifact_ref": "blob-qr-001", "artifact_type": "qr_invoice"}
+        )
+        resp = await client.post("/api/artifacts/fetch", content=body, headers=headers)
+
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["content-type"] == "application/vnd.helium.invoice-qr+json"
+        assert resp.content == qr_bytes
+        # QR blobs carry the de-branded durable-invoice-data marker.
+        assert resp.headers["x-relay-durable-invoice-data"] == "qr_bytes"
+        _assert_no_sbs_headers(resp)
+
+    @pytest.mark.asyncio
+    async def test_backend_copy_scout_kind_routes_to_pdf_bytes(self, app_and_client):
+        """``backend_copy`` is the Scout adapter's name for a backend PDF copy
+        (scout.py:7981/8193) — must route to HARD/PDF bytes, not JSON."""
+        app, client = app_and_client
+
+        async def fake_fetch_blob(artifact_ref, jwt_token=None):
+            return {"content_type": "application/pdf", "data": b"%PDF-1.4\nx\n%%EOF"}
+
+        async def boom_lifecycle(artifact_ref, artifact_type=None):
+            raise AssertionError("backend_copy must route to bytes, not lifecycle")
+
+        app.state.heartbeat.fetch_blob = fake_fetch_blob
+        app.state.core.fetch_lifecycle_artifact = boom_lifecycle
+
+        body, headers = _post_args(
+            {"artifact_ref": "blob-backend-1", "artifact_type": "backend_copy"}
+        )
+        resp = await client.post("/api/artifacts/fetch", content=body, headers=headers)
+
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["content-type"] == "application/pdf"
+
+
+# ── LIFECYCLE artifact → JSON ─────────────────────────────────────────────
+
+
+class TestLifecycleArtifactJson:
+    @pytest.mark.asyncio
+    async def test_hlx_returns_raw_json(self, app_and_client):
+        app, client = app_and_client
+        payload = {"document_id": "doc-1", "summary": "HLX body", "artifact_family": "hlx"}
+
+        async def fake_fetch_lifecycle(artifact_ref, artifact_type=None):
+            assert artifact_ref == "hlx-ref-001"
+            assert artifact_type == "hlx"
+            return payload
+
+        # If the route mistakenly took the HARD path it would hit fetch_blob;
+        # make that explode so the test fails loudly on misrouting.
+        async def boom_fetch_blob(artifact_ref, jwt_token=None):
+            raise AssertionError("hlx must route to lifecycle JSON, not bytes")
+
+        app.state.core.fetch_lifecycle_artifact = fake_fetch_lifecycle
+        app.state.heartbeat.fetch_blob = boom_fetch_blob
+
+        body, headers = _post_args(
+            {"artifact_ref": "hlx-ref-001", "artifact_type": "hlx"}
+        )
+        resp = await client.post("/api/artifacts/fetch", content=body, headers=headers)
+
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["content-type"].startswith("application/json")
+        assert resp.json() == payload
+        assert resp.headers["x-relay-artifact-kind"] == "lifecycle"
+        assert resp.headers["x-relay-artifact-ref"] == "hlx-ref-001"
+        assert resp.headers["x-relay-artifact-etag"].startswith("sha256:")
+        _assert_no_sbs_headers(resp)
+
+    @pytest.mark.asyncio
+    async def test_manifest_inferred_as_json_without_artifact_type(self, app_and_client):
+        """No artifact_type → ref prefix ``manifest-`` infers a lifecycle JSON
+        (SBS parity, relay.py:1035)."""
+        app, client = app_and_client
+        payload = {"artifact_ref": "manifest-doc-9", "artifacts": {"signed_pdf_ref": "x"}}
+
+        async def fake_fetch_lifecycle(artifact_ref, artifact_type=None):
+            assert artifact_ref == "manifest-doc-9"
+            return payload
+
+        async def boom_fetch_blob(artifact_ref, jwt_token=None):
+            raise AssertionError("manifest must route to lifecycle JSON, not bytes")
+
+        app.state.core.fetch_lifecycle_artifact = fake_fetch_lifecycle
+        app.state.heartbeat.fetch_blob = boom_fetch_blob
+
+        body, headers = _post_args({"artifact_ref": "manifest-doc-9"})
+        resp = await client.post("/api/artifacts/fetch", content=body, headers=headers)
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == payload
+        assert resp.headers["x-relay-artifact-kind"] == "lifecycle"
+
+
+# ── Miss → 404 contract body ──────────────────────────────────────────────
+
+
+class TestArtifactNotFound:
+    @pytest.mark.asyncio
+    async def test_hard_miss_returns_404_contract_body(self, app_and_client):
+        app, client = app_and_client
+
+        async def fake_fetch_blob(artifact_ref, jwt_token=None):
+            return None  # HB miss
+
+        app.state.heartbeat.fetch_blob = fake_fetch_blob
+
+        body, headers = _post_args(
+            {"artifact_ref": "blob-missing", "artifact_type": "signed_pdf"}
+        )
+        resp = await client.post("/api/artifacts/fetch", content=body, headers=headers)
+
+        assert resp.status_code == 404
+        # EXACT contract body — no status/error_code/message/details envelope.
+        assert resp.json() == {"code": "ARTIFACT_NOT_FOUND", "artifact_ref": "blob-missing"}
+        _assert_no_sbs_headers(resp)
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_miss_returns_404_contract_body(self, app_and_client):
+        app, client = app_and_client
+
+        async def fake_fetch_lifecycle(artifact_ref, artifact_type=None):
+            return None  # Core miss
+
+        app.state.core.fetch_lifecycle_artifact = fake_fetch_lifecycle
+
+        body, headers = _post_args(
+            {"artifact_ref": "hlx-missing", "artifact_type": "hlx"}
+        )
+        resp = await client.post("/api/artifacts/fetch", content=body, headers=headers)
+
+        assert resp.status_code == 404
+        assert resp.json() == {"code": "ARTIFACT_NOT_FOUND", "artifact_ref": "hlx-missing"}
+
+    @pytest.mark.asyncio
+    async def test_missing_artifact_ref_returns_404_empty_ref(self, app_and_client):
+        """An absent artifact_ref can never resolve → 404 with empty-ref body.
+        (No path source exists — VERB_DELTA forbids a path ref.)"""
+        app, client = app_and_client
+
+        async def boom_fetch_blob(artifact_ref, jwt_token=None):
+            raise AssertionError("must not reach HB for an empty ref")
+
+        app.state.heartbeat.fetch_blob = boom_fetch_blob
+
+        body, headers = _post_args({"artifact_type": "signed_pdf"})
+        resp = await client.post("/api/artifacts/fetch", content=body, headers=headers)
+
+        assert resp.status_code == 404
+        assert resp.json() == {"code": "ARTIFACT_NOT_FOUND", "artifact_ref": ""}
+
+
+# ── VERB: POST-only, body-not-path ────────────────────────────────────────
+
+
+class TestVerbAndBody:
+    @pytest.mark.asyncio
+    async def test_no_get_variant_with_ref_in_path(self, app_and_client):
+        """There is NO ``GET /api/artifacts/<ref>`` — the ref must not be in a URL."""
+        app, client = app_and_client
+        resp = await client.get("/api/artifacts/blob-signed-001")
+        assert resp.status_code in (404, 405)  # route simply does not exist
+
+    @pytest.mark.asyncio
+    async def test_artifact_ref_read_from_body_not_path(self, app_and_client):
+        """The body's artifact_ref is the one fetched (proves body-sourcing)."""
+        app, client = app_and_client
+        seen = {}
+
+        async def fake_fetch_blob(artifact_ref, jwt_token=None):
+            seen["ref"] = artifact_ref
+            return {"content_type": "application/pdf", "data": b"%PDF-1.4\nx\n%%EOF"}
+
+        app.state.heartbeat.fetch_blob = fake_fetch_blob
+
+        body, headers = _post_args(
+            {"artifact_ref": "from-body-ref", "artifact_type": "original_pdf"}
+        )
+        resp = await client.post("/api/artifacts/fetch", content=body, headers=headers)
+        assert resp.status_code == 200, resp.text
+        assert seen["ref"] == "from-body-ref"
+
+
+# ── Auth required ─────────────────────────────────────────────────────────
+
+
+class TestAuthRequired:
+    @pytest.mark.asyncio
+    async def test_no_credentials_rejected(self, app_and_client):
+        """Without HMAC/Bearer headers, the shared dispatcher rejects (401)."""
+        _, client = app_and_client
+        body = json.dumps(
+            {"artifact_ref": "blob-1", "artifact_type": "signed_pdf"}
+        ).encode("utf-8")
+        resp = await client.post(
+            "/api/artifacts/fetch",
+            content=body,
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 401
+        assert resp.json()["error_code"] == "AUTHENTICATION_FAILED"
+
+    @pytest.mark.asyncio
+    async def test_bad_signature_rejected(self, app_and_client):
+        _, client = app_and_client
+        body = json.dumps(
+            {"artifact_ref": "blob-1", "artifact_type": "signed_pdf"}
+        ).encode("utf-8")
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        headers = {
+            "X-API-Key": TEST_API_KEY,
+            "X-Timestamp": ts,
+            "X-Signature": "deadbeef",  # wrong
+            "Content-Type": "application/json",
+        }
+        resp = await client.post("/api/artifacts/fetch", content=body, headers=headers)
+        assert resp.status_code == 401
+
+
+# ── classify_artifact unit coverage ───────────────────────────────────────
+
+
+class TestClassifyArtifact:
+    @pytest.mark.parametrize(
+        "artifact_type,expected_ct",
+        [
+            ("signed_pdf", "application/pdf"),
+            ("fixed_pdf", "application/pdf"),
+            ("original_pdf", "application/pdf"),
+            ("backend_pdf", "application/pdf"),
+            ("backend_copy", "application/pdf"),
+            ("qr_invoice", "application/vnd.helium.invoice-qr+json"),
+            ("qr_blob", "application/vnd.helium.invoice-qr+json"),
+            ("signature", "application/octet-stream"),
+        ],
+    )
+    def test_hard_kinds(self, artifact_type, expected_ct):
+        kind_class, content_type = classify_artifact(
+            artifact_type=artifact_type, artifact_ref="ref-x"
+        )
+        assert kind_class == "hard"
+        assert content_type == expected_ct
+
+    @pytest.mark.parametrize(
+        "artifact_type",
+        [
+            "hlx",
+            "firs_returned_artifact",
+            "approval_lifecycle_json",
+            "approval_lifecycle",
+            "manifest",
+        ],
+    )
+    def test_lifecycle_kinds(self, artifact_type):
+        kind_class, content_type = classify_artifact(
+            artifact_type=artifact_type, artifact_ref="ref-x"
+        )
+        assert kind_class == "lifecycle"
+        assert content_type is None
+
+    def test_manifest_prefix_inference_without_type(self):
+        kind_class, _ = classify_artifact(
+            artifact_type=None, artifact_ref="manifest-doc-1"
+        )
+        assert kind_class == "lifecycle"
+
+    def test_unknown_type_falls_back_to_hard_pdf(self):
+        kind_class, content_type = classify_artifact(
+            artifact_type="totally_unknown", artifact_ref="ref-x"
+        )
+        assert kind_class == "hard"
+        assert content_type == "application/pdf"
+
+    def test_unknown_type_with_manifest_prefix_is_lifecycle(self):
+        """Unknown explicit kind still honours the manifest- prefix fallback."""
+        kind_class, _ = classify_artifact(
+            artifact_type="totally_unknown", artifact_ref="manifest-doc-1"
+        )
+        assert kind_class == "lifecycle"
+
+    def test_case_insensitive_type(self):
+        kind_class, _ = classify_artifact(
+            artifact_type="SIGNED_PDF", artifact_ref="ref-x"
+        )
+        assert kind_class == "hard"


### PR DESCRIPTION
## R-M4 §B-RelayArtifactFetch — `POST /api/artifacts/fetch` (`X-Relay-Artifact-*`)

NEW **`POST /api/artifacts/fetch { artifact_ref, artifact_type }`** (default `artifact_type="qr_invoice"`). Scout-callable; returns **bytes** for hard artifacts (Content-Type per kind), **raw JSON** for lifecycle artifacts. Miss → **`404 {code:"ARTIFACT_NOT_FOUND", artifact_ref}`**. Auth via the combined `authenticate_request` dispatcher.

**VERB_DELTA (load-bearing):** POST-body — `artifact_ref` is a bearer capability, **never** in a URL/querystring. Response headers are **`X-Relay-Artifact-*`** (`X-Relay-Artifact`, `-Ref`, `-Kind`, `-ETag`) — the SBS-branded `X-SBS-*` headers are explicitly **NOT** shipped (SBS is a mock).

**Kind classification (proposed — ARCH/Scout ratify):** request-signalled via `artifact_type` with fallback inference from the ref prefix (`manifest-`→JSON). Split per §B hard-vs-lifecycle: **hard/bytes** = `qr_invoice`, `signed_pdf`/`fixed_pdf`/`original_pdf`/`backend_pdf` (application/pdf), `signature` (octet-stream); **lifecycle/JSON** = `hlx`, `firs_returned_artifact`, `approval_lifecycle_json`, `manifest`. Concrete map in `services/relay/src/api/routes/artifacts.py` (classification ~`:114-129`).

**Tests:** **seat verified full suite — 666 passed / 7 pre-existing failed** (the documented ingest_route ×2 / irn ×1 / qr ×3 / external ×1; no new regression). Route tests assert POST-only (no GET), bytes-vs-JSON by kind, the 404 shape, `artifact_ref` read from BODY, `X-Relay-Artifact-*` present + `X-SBS-*` absent, auth required (HB/Core client mocked; Redis mocked per A1).

**Cross-seat NEEDS:** HB blob-fetch-by-ref for Relay service creds; Core HLX/lifecycle ref shape. `HeartBeatClient`/`CoreClient` carry thin methods pending the real endpoints (note: agent's final report was truncated — the seat verified the code/tests directly).

Base `b2afaa6` (post #20/#23/#24). Branch `feat/relay-cssv1-rm4-artifact-fetch-v2` @ `9d193a4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
