### PR TITLE
feat(relay): L5 Ed25519 webhook verifier (no-kid JWKS) — supersedes symmetric-HMAC #22

### DIFF
--- a/services/relay/src/api/app.py
+++ b/services/relay/src/api/app.py
@@ -52,6 +52,8 @@ from .routes.ingest import router as ingest_router
 from .routes.internal import router as internal_router
 from .routes.metrics import router as metrics_router
 from .routes.status import router as status_router
+from .routes.webhook import router as webhook_router
+from .webhook_auth import build_webhook_verifier
 
 logger = logging.getLogger(__name__)
 
@@ -201,6 +203,14 @@ def create_app(
         else:
             logger.info("Ingest ledger disabled (RELAY_DB_PATH unset)")
 
+        # Webhook receiver (L5) — verifies HB's Ed25519-signed webhooks
+        # against HB's published webhook public key, fetched by ``kid`` via a
+        # JWKSCache. Its own httpx client (closed on shutdown) so the JWKS
+        # fetch is isolated from the s2s clients. PROVISIONAL contract — see
+        # webhook_auth.py NEEDS-FROM-HB. No symmetric HMAC path exists.
+        webhook_jwks_http = httpx.AsyncClient(timeout=config.request_timeout_s)
+        webhook_verifier = build_webhook_verifier(config, webhook_jwks_http)
+
         # Service layer
         ingestion = IngestionService(
             config, heartbeat, core,
@@ -242,6 +252,8 @@ def create_app(
         app.state.finalize_service = finalize_service
         app.state.status_service = status_service
         app.state.amqp_consumer = amqp_consumer
+        app.state.webhook_verifier = webhook_verifier
+        app.state.webhook_jwks_http = webhook_jwks_http
 
         # Q37 Gap #2 — OAuth JWKS validator (optional, gated on RELAY_JWKS_URL).
         # Instantiated only when the URL is configured; otherwise oauth_validator
@@ -276,6 +288,7 @@ def create_app(
             await _jwks_http_client.aclose()
         if ingest_ledger is not None:
             ingest_ledger.close()
+        await webhook_jwks_http.aclose()
 
     app = FastAPI(
         title="Relay-API",
@@ -306,5 +319,6 @@ def create_app(
     app.include_router(duplicate_router)
     app.include_router(artifacts_router)
     app.include_router(status_router)
+    app.include_router(webhook_router)
 
     return app

--- a/services/relay/src/api/routes/webhook.py
+++ b/services/relay/src/api/routes/webhook.py
@@ -1,0 +1,70 @@
+"""
+Ed25519 webhook receive route — L5.
+
+``POST /api/webhook`` — HeartBeat pushes a webhook; Relay verifies its
+**Ed25519** signature (see :mod:`src.api.webhook_auth`) and 200s.
+
+This is the consumer side of the L5 rework: HB signs with Ed25519 (reusing
+its OAuth JWKS infra + a published webhook public key), Relay verifies against
+that key fetched by ``kid``. There is **no symmetric HMAC** anywhere on this
+path — the earlier shared-secret receiver was reversed by the ARCH "Bob
+ratification pass" 2026-06-19 (ledger L5).
+
+The route deliberately does the minimum: verify, then return ``200``.
+Message-type dispatch is OUT OF SCOPE here (a separate harmonization) — see
+the NEEDS-FROM-HB note at the dispatch seam below.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel
+
+from ..webhook_auth import WebhookVerifier, get_webhook_verifier
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class WebhookAck(BaseModel):
+    """200 acknowledgement body for a verified webhook delivery."""
+
+    status: str = "ok"
+
+
+@router.post(
+    "/api/webhook",
+    response_model=WebhookAck,
+    summary="Receive an Ed25519-signed HeartBeat webhook (L5)",
+)
+async def receive_webhook(
+    request: Request,
+    verifier: WebhookVerifier = Depends(get_webhook_verifier),
+) -> WebhookAck:
+    """Verify the inbound webhook's Ed25519 signature, then acknowledge.
+
+    On signature failure :meth:`WebhookVerifier.verify` raises a 401
+    ``WebhookSignatureError`` which the global ``relay_error_handler`` renders;
+    this handler is only reached when verification passed.
+    """
+    # Ed25519 signature verification (raises 401 WebhookSignatureError on fail).
+    await verifier.verify(request)
+
+    trace_id = getattr(request.state, "trace_id", "")
+
+    # ──────────────────────────────────────────────────────────────────────
+    # NEEDS-FROM-HB: message-type dispatch goes HERE.
+    #
+    # This is a SEPARATE harmonization, NOT part of the L5 receiver-rework
+    # task. Once HeartBeat publishes the webhook MESSAGE-TYPE CATALOGUE (what
+    # event kinds it pushes — e.g. config_changed, key_rotation, lifecycle
+    # updates — and the body schema for each), parse the verified body here
+    # and route to the matching handler. Until then the verified delivery is
+    # acknowledged with a bare 200 and no body interpretation.
+    # ──────────────────────────────────────────────────────────────────────
+    logger.info("[%s] Webhook received + Ed25519-verified (no dispatch yet).", trace_id)
+
+    return WebhookAck(status="ok")

--- a/services/relay/src/api/webhook_auth.py
+++ b/services/relay/src/api/webhook_auth.py
@@ -1,10 +1,10 @@
 """
-Ed25519-signed webhook receiver verifier — L5 (reworked from symmetric HMAC).
+Ed25519-signed webhook receiver verifier — L5 (LOCKED contract).
 
-HeartBeat (producer) SIGNS each webhook with **Ed25519**, reusing its OAuth
-JWKS Ed25519 infrastructure and publishing the webhook public key. Relay
-(consumer) VERIFIES that signature here against HB's published webhook public
-key, fetched by ``kid`` via the shared :class:`~src.core.jwks_cache.JWKSCache`.
+HeartBeat (producer) SIGNS each webhook with **Ed25519**, reusing the SAME
+Ed25519 signing key it publishes on its OAuth JWKS. Relay (consumer) VERIFIES
+that signature here against HB's published Ed25519 public key(s), fetched via
+the shared :class:`~src.core.jwks_cache.JWKSCache`.
 
 This REPLACES the earlier symmetric, shared-secret receiver (the 2-header /
 ``sha256=`` HMAC ``verify_webhook_request`` that shipped on
@@ -16,10 +16,9 @@ signing key. Verification is asymmetric only.
 
 Reuse (no second JWKS/Ed25519 fetcher is written here):
     - :class:`src.core.jwks_cache.JWKSCache` — fetches Ed25519 public keys
-      from HB's JWKS by ``kid`` (1h TTL, online rotation, fail-soft).
-    - The Ed25519 verify pattern + base64url-decode helper are modelled on
-      ``src.core.oauth_validator`` (``pub_key.verify(raw_sig, signing_input)``
-      + ``InvalidSignature`` handling).
+      from HB's JWKS (1h TTL, online rotation, fail-soft).
+    - The Ed25519 verify pattern is modelled on ``src.core.oauth_validator``
+      (``pub_key.verify(raw_sig, signing_input)`` + ``InvalidSignature``).
 
 Layout:
     - :class:`WebhookVerifier` is the verifier. It takes a ``JWKSCache`` and a
@@ -34,52 +33,43 @@ Layout:
       ``httpx.AsyncClient`` (used by the lifespan).
 
 ╔══════════════════════════════════════════════════════════════════════════╗
-║  NEEDS-FROM-HB  —  PROVISIONAL CONTRACT (not finalized; do NOT treat as   ║
-║                    settled until HeartBeat publishes the webhook spec).   ║
+║  LOCKED L5 WEBHOOK CONTRACT  (CONTRACT_LEDGER L5, 2026-06-20)             ║
 ╠══════════════════════════════════════════════════════════════════════════╣
-║ Everything below is Relay's *best-guess* placeholder so the receiver is   ║
-║ buildable + testable TODAY. Each item is owned by HeartBeat and MUST be   ║
-║ reconciled before this path is enabled against a real HB producer. The    ║
-║ constants are centralised (module-level) precisely so a one-line change   ║
-║ reconciles each one once HB confirms.                                     ║
+║ ARCH locked this against HeartBeat #182's signer (ground-truthed). This   ║
+║ verifier MUST accept exactly the signatures HB produces. The constants    ║
+║ below are the single source of truth for the wire format.                 ║
 ║                                                                           ║
-║ 1. EXACT SIGNING INPUT (the bytes HB feeds to Ed25519.sign).              ║
-║    Provisional: the ASCII bytes of                                        ║
-║        f"{webhook_id}:{timestamp}:{sha256_hex(body)}"                     ║
-║    i.e. ``"<X-HeartBeat-Webhook-Id>:<X-HeartBeat-Timestamp>:"`` followed  ║
-║    by the lowercase hex SHA-256 of the EXACT raw request body bytes.      ║
-║    OPEN: does HB sign the raw body directly (like the old HMAC receiver,  ║
-║    which signed ``f"{ts}.".encode()+body``) or this digest-of-body form?  ║
-║    OPEN: field order, separator char (':' vs '.'), and whether            ║
-║    ``webhook_id`` participates at all.                                    ║
+║ 1. SIGNING INPUT (the bytes HB feeds to Ed25519.sign):                    ║
+║        f"{unix_ts}.".encode("utf-8") + raw_body_bytes                     ║
+║    i.e. the ASCII of the unix-epoch-seconds timestamp, then a literal     ║
+║    ``.``, then the EXACT raw request body bytes. NO webhook_id, NO        ║
+║    sha256 digest, NO colons.                                             ║
 ║                                                                           ║
-║ 2. EXACT HEADER NAMES.                                                    ║
-║    Provisional:                                                           ║
-║        X-HeartBeat-Key-Id     → JWKS ``kid`` of the webhook signing key   ║
-║        X-HeartBeat-Timestamp  → Unix epoch seconds (ASCII int)            ║
-║        X-HeartBeat-Signature  → base64url(Ed25519 signature), no padding  ║
-║        X-HeartBeat-Webhook-Id → opaque per-delivery id (in signing input) ║
-║    OPEN: HB may keep the old ``X-HeartBeat-Signature`` name but DROP the  ║
-║    ``sha256=`` prefix (this scheme has no prefix), may rename Key-Id to   ║
-║    ``X-HeartBeat-Kid``, and may not send a Webhook-Id at all.             ║
+║ 2. HEADERS:                                                               ║
+║        X-HeartBeat-Signature: ed25519=<standard-base64 signature>        ║
+║        X-HeartBeat-Timestamp: <unix epoch seconds, ASCII int>            ║
+║    The signature value carries a literal ``ed25519=`` prefix; after       ║
+║    stripping it, the remainder is STANDARD base64 (``base64.b64decode``,  ║
+║    matching Core #176 — NOT urlsafe / no-pad). There is NO Key-Id header  ║
+║    and NO Webhook-Id header in the locked contract.                       ║
 ║                                                                           ║
-║ 3. WHERE HB PUBLISHES THE WEBHOOK PUBLIC KEY.                             ║
-║    Provisional: the SAME ``/.well-known/jwks.json`` as the OAuth signer,  ║
-║    distinguished by a distinct ``kid`` and ``use:"sig"`` (so ``jwks_url`` ║
-║    is reused and ``RELAY_WEBHOOK_JWKS_URL`` is left empty).               ║
-║    OPEN: HB may instead expose a DEDICATED webhook-keys endpoint; if so,  ║
-║    set ``RELAY_WEBHOOK_JWKS_URL`` to it (already plumbed in config.py).   ║
+║ 3. REPLAY WINDOW: 5 minutes (300s) absolute skew on the timestamp.        ║
 ║                                                                           ║
-║ 4. (separate harmonization, NOT this task) the MESSAGE-TYPE CATALOGUE —   ║
+║ 4. KEY RESOLUTION: no kid travels in the headers, so the key cannot be    ║
+║    looked up by a header kid. HB publishes ONE Ed25519 signing key on     ║
+║    ``/.well-known/jwks.json`` (rarely 2 during rotation). Relay fetches   ║
+║    the JWKS and tries verifying against EACH published Ed25519 key,       ║
+║    accepting if ANY verifies (``JWKSCache.get_all_keys()``).             ║
+║                                                                           ║
+║ 5. (separate harmonization, NOT this task) the MESSAGE-TYPE CATALOGUE —   ║
 ║    what message kinds HB pushes and how Relay dispatches them. The route  ║
-║    below verifies + 200s only; dispatch is a documented TODO there.       ║
+║    verifies + 200s only; dispatch is a documented TODO there.             ║
 ╚══════════════════════════════════════════════════════════════════════════╝
 """
 
 from __future__ import annotations
 
 import base64
-import hashlib
 import logging
 import time
 from typing import Optional
@@ -94,59 +84,48 @@ from ..errors import WebhookSignatureError
 logger = logging.getLogger(__name__)
 
 
-# ── PROVISIONAL contract constants (see NEEDS-FROM-HB in the module docstring) ──
+# ── LOCKED contract constants (CONTRACT_LEDGER L5, 2026-06-20) ──────────────
 #
-# These are the single source of truth for the provisional wire format. When
-# HeartBeat finalizes the webhook signing spec, reconcile by editing HERE.
+# Single source of truth for the wire format. Locked against HB #182's signer.
 
-#: Header carrying the JWKS ``kid`` of the webhook signing key. PROVISIONAL.
-HEADER_KEY_ID = "x-heartbeat-key-id"
-#: Header carrying the Unix-epoch-seconds timestamp (ASCII int). PROVISIONAL.
+#: Header carrying the Unix-epoch-seconds timestamp (ASCII int).
 HEADER_TIMESTAMP = "x-heartbeat-timestamp"
-#: Header carrying base64url(Ed25519 signature), no padding. PROVISIONAL.
+#: Header carrying ``ed25519=<standard-base64 signature>``.
 HEADER_SIGNATURE = "x-heartbeat-signature"
-#: Header carrying the opaque per-delivery webhook id. PROVISIONAL.
-HEADER_WEBHOOK_ID = "x-heartbeat-webhook-id"
+#: Literal prefix the signature header value must carry, before the base64.
+SIGNATURE_SCHEME_PREFIX = "ed25519="
 
 
-def _b64url_decode(segment: str) -> bytes:
-    """Decode a base64url segment (issuer may omit padding).
-
-    Modelled on ``src.core.oauth_validator._b64url_decode`` — the same helper
-    the OAuth path uses to decode the JWT signature segment, kept byte-for-byte
-    compatible so both paths agree on the encoding HB emits.
-    """
-    padded = segment + "=" * (-len(segment) % 4)
-    return base64.urlsafe_b64decode(padded.encode("ascii"))
-
-
-def _build_signing_input(webhook_id: str, timestamp: str, body_bytes: bytes) -> bytes:
+def _build_signing_input(timestamp: str, body_bytes: bytes) -> bytes:
     """Reconstruct the exact bytes HeartBeat signed.
 
-    PROVISIONAL (NEEDS-FROM-HB item #1): the ASCII bytes of
-    ``f"{webhook_id}:{timestamp}:{sha256_hex(body)}"``. The body is reduced to
-    its lowercase-hex SHA-256 so the signed message is bounded regardless of
-    payload size; HB MUST sign the identical construction.
+    LOCKED (CONTRACT_LEDGER L5, 2026-06-20): the UTF-8 ASCII of the
+    unix-epoch-seconds timestamp, a literal ``.``, then the EXACT raw request
+    body bytes — ``f"{timestamp}.".encode("utf-8") + body_bytes``. No
+    webhook_id, no sha256 digest, no colons. HB signs this identical
+    construction over the raw body.
     """
-    body_hash = hashlib.sha256(body_bytes).hexdigest()
-    return f"{webhook_id}:{timestamp}:{body_hash}".encode("ascii")
+    return f"{timestamp}.".encode("utf-8") + body_bytes
 
 
 class WebhookVerifier:
     """Verifies an inbound HeartBeat webhook's **Ed25519** signature.
 
-    The webhook public key is fetched by ``kid`` from HB's published JWKS via
-    the shared :class:`JWKSCache` (no second fetcher). On ANY failure a
+    The webhook public key(s) are fetched from HB's published JWKS via the
+    shared :class:`JWKSCache` (no second fetcher). The locked contract carries
+    no kid header, so verification is attempted against EVERY published
+    Ed25519 key and succeeds if ANY one verifies. On ANY failure a
     :class:`WebhookSignatureError` (HTTP 401) is raised — the route lets it
     bubble to the global ``relay_error_handler``.
 
     Parameters
     ----------
     jwks_cache:
-        Shared :class:`JWKSCache` pointed at HB's webhook-key JWKS URL.
+        Shared :class:`JWKSCache` pointed at HB's JWKS URL (the same JWKS that
+        publishes the OAuth Ed25519 signing key).
     replay_window_s:
         Max allowed absolute skew (seconds) between the signed timestamp and
-        ``now`` before the delivery is rejected as a replay. PROVISIONAL.
+        ``now`` before the delivery is rejected as a replay. LOCKED at 300s.
     """
 
     def __init__(self, jwks_cache: JWKSCache, replay_window_s: int = 300) -> None:
@@ -160,13 +139,12 @@ class WebhookVerifier:
         :class:`WebhookSignatureError`; the client-facing message is generic
         so a probe cannot distinguish the failure modes):
 
-            1. ``kid`` header present.
-            2. ``timestamp`` header present + integer.
-            3. ``signature`` header present.
-            4. timestamp inside the replay window.
-            5. webhook public key for ``kid`` resolvable from the JWKS.
-            6. signature base64url-decodes.
-            7. Ed25519 verify of the signature over the reconstructed input.
+            1. ``timestamp`` header present + integer.
+            2. ``signature`` header present + ``ed25519=`` prefix + base64.
+            3. timestamp inside the replay window.
+            4. at least one published Ed25519 key resolvable from the JWKS.
+            5. Ed25519 verify of the signature over the reconstructed input
+               against EACH published key — accept if ANY verifies.
 
         On success returns ``None`` and the handler runs. Body bytes are read
         from ``request.state.raw_body`` (populated by ``BodyCacheMiddleware``)
@@ -175,22 +153,27 @@ class WebhookVerifier:
         """
         headers = request.headers
 
-        # ── Step 1: kid header ───────────────────────────────────────────
-        kid = headers.get(HEADER_KEY_ID, "")
-        if not kid:
-            raise WebhookSignatureError(reason="missing key-id header")
-
-        # ── Step 2: timestamp header present + integer ───────────────────
+        # ── Step 1: timestamp header present + integer ───────────────────
         timestamp_raw = headers.get(HEADER_TIMESTAMP, "")
         if not timestamp_raw or not timestamp_raw.lstrip("-").isdigit():
             raise WebhookSignatureError(reason="missing or non-integer timestamp")
 
-        # ── Step 3: signature header present ─────────────────────────────
-        signature_b64 = headers.get(HEADER_SIGNATURE, "")
-        if not signature_b64:
+        # ── Step 2: signature header present + ed25519= prefix + base64 ──
+        signature_header = headers.get(HEADER_SIGNATURE, "")
+        if not signature_header:
             raise WebhookSignatureError(reason="missing signature header")
+        if not signature_header.startswith(SIGNATURE_SCHEME_PREFIX):
+            raise WebhookSignatureError(
+                reason="signature header missing ed25519= prefix"
+            )
+        signature_b64 = signature_header[len(SIGNATURE_SCHEME_PREFIX):]
+        try:
+            # Standard base64 (NOT urlsafe / no-pad) — matches Core #176.
+            raw_sig = base64.b64decode(signature_b64, validate=True)
+        except Exception as exc:
+            raise WebhookSignatureError(reason="signature decode failed") from exc
 
-        # ── Step 4: timestamp inside replay window ───────────────────────
+        # ── Step 3: timestamp inside replay window ───────────────────────
         timestamp = int(timestamp_raw)
         now = int(time.time())
         if abs(now - timestamp) > self._replay_window_s:
@@ -200,44 +183,46 @@ class WebhookVerifier:
             )
             raise WebhookSignatureError(reason="timestamp outside replay window")
 
-        # ── Step 5: resolve webhook public key by kid ────────────────────
+        # ── Step 4: resolve the published Ed25519 key(s) ─────────────────
+        # The locked contract sends no kid, so we cannot look a single key up.
+        # Fetch ALL published Ed25519 keys (HB publishes one, rarely two during
+        # rotation) and try each below.
         try:
-            pub_key = await self._cache.get_key(kid)
+            pub_keys = await self._cache.get_all_keys()
         except Exception as exc:
             # Cold-start JWKS fetch failure — fail closed (401), never admit
             # an unverified webhook. JWKSCache itself is fail-soft on refresh.
             logger.warning("Webhook rejected — JWKS fetch failed: %s", exc)
             raise WebhookSignatureError(reason="jwks fetch failed") from exc
-        if pub_key is None:
-            raise WebhookSignatureError(reason=f"kid={kid!r} not in webhook JWKS")
+        if not pub_keys:
+            raise WebhookSignatureError(reason="no Ed25519 keys in webhook JWKS")
 
-        # ── Step 6: decode signature ─────────────────────────────────────
-        try:
-            raw_sig = _b64url_decode(signature_b64)
-        except Exception as exc:
-            raise WebhookSignatureError(reason="signature decode failed") from exc
-
-        # ── Step 7: Ed25519 verify over the reconstructed signing input ──
-        webhook_id = headers.get(HEADER_WEBHOOK_ID, "")
+        # ── Step 5: Ed25519 verify over the reconstructed signing input ──
+        # Accept if ANY published key verifies the signature.
         body_bytes = await self._read_body(request)
-        signing_input = _build_signing_input(webhook_id, timestamp_raw, body_bytes)
-        try:
-            pub_key.verify(raw_sig, signing_input)
-        except InvalidSignature as exc:
-            logger.warning(
-                "Webhook rejected — Ed25519 signature mismatch (kid=%s, ts=%s).",
-                kid, timestamp_raw,
-            )
-            raise WebhookSignatureError(reason="ed25519 signature mismatch") from exc
-        except Exception as exc:
-            raise WebhookSignatureError(
-                reason=f"ed25519 verify error: {exc}"
-            ) from exc
+        signing_input = _build_signing_input(timestamp_raw, body_bytes)
+        for pub_key in pub_keys:
+            try:
+                pub_key.verify(raw_sig, signing_input)
+            except InvalidSignature:
+                continue  # try the next published key
+            except Exception as exc:
+                # A non-signature verify error (e.g. malformed key) is unusual;
+                # log and keep trying the remaining keys rather than admitting.
+                logger.warning("Webhook key verify raised (non-signature): %s", exc)
+                continue
+            else:
+                logger.debug(
+                    "Webhook Ed25519 signature verified — ts=%s", timestamp_raw,
+                )
+                return
 
-        logger.debug(
-            "Webhook Ed25519 signature verified — kid=%s webhook_id=%s ts=%s",
-            kid, webhook_id or "(none)", timestamp_raw,
+        logger.warning(
+            "Webhook rejected — Ed25519 signature did not match any of %d "
+            "published key(s) (ts=%s).",
+            len(pub_keys), timestamp_raw,
         )
+        raise WebhookSignatureError(reason="ed25519 signature mismatch")
 
     @staticmethod
     async def _read_body(request: Request) -> bytes:
@@ -258,9 +243,9 @@ def build_webhook_verifier(
     """Construct a :class:`WebhookVerifier` + its backing :class:`JWKSCache`.
 
     The JWKS URL is ``RELAY_WEBHOOK_JWKS_URL`` if set, else falls back to the
-    base ``RELAY_JWKS_URL`` (the same-JWKS-distinct-kid hypothesis — see
-    NEEDS-FROM-HB item #3). Called once at startup by ``create_app``'s
-    lifespan with the shared httpx client.
+    base ``RELAY_JWKS_URL`` (the same JWKS that publishes HB's OAuth Ed25519
+    signing key — the locked contract reuses that one key). Called once at
+    startup by ``create_app``'s lifespan with the shared httpx client.
     """
     jwks_url = config.webhook_jwks_url or config.jwks_url
     cache = JWKSCache(jwks_url=jwks_url, http_client=http_client)
@@ -291,8 +276,7 @@ __all__ = [
     "WebhookVerifier",
     "build_webhook_verifier",
     "get_webhook_verifier",
-    "HEADER_KEY_ID",
     "HEADER_TIMESTAMP",
     "HEADER_SIGNATURE",
-    "HEADER_WEBHOOK_ID",
+    "SIGNATURE_SCHEME_PREFIX",
 ]

--- a/services/relay/src/api/webhook_auth.py
+++ b/services/relay/src/api/webhook_auth.py
@@ -1,0 +1,298 @@
+"""
+Ed25519-signed webhook receiver verifier — L5 (reworked from symmetric HMAC).
+
+HeartBeat (producer) SIGNS each webhook with **Ed25519**, reusing its OAuth
+JWKS Ed25519 infrastructure and publishing the webhook public key. Relay
+(consumer) VERIFIES that signature here against HB's published webhook public
+key, fetched by ``kid`` via the shared :class:`~src.core.jwks_cache.JWKSCache`.
+
+This REPLACES the earlier symmetric, shared-secret receiver (the 2-header /
+``sha256=`` HMAC ``verify_webhook_request`` that shipped on
+``feat/relay-cssv1-s4-hash-lib-record-duplicate-webhook``). Per the ARCH
+"Bob ratification pass" 2026-06-19 (ledger L5), the symmetric-HMAC ruling was
+**reversed**: there is intentionally **no symmetric HMAC code path** in this
+module — no shared secret, no ``hmac``/``hashlib`` import, no per-service
+signing key. Verification is asymmetric only.
+
+Reuse (no second JWKS/Ed25519 fetcher is written here):
+    - :class:`src.core.jwks_cache.JWKSCache` — fetches Ed25519 public keys
+      from HB's JWKS by ``kid`` (1h TTL, online rotation, fail-soft).
+    - The Ed25519 verify pattern + base64url-decode helper are modelled on
+      ``src.core.oauth_validator`` (``pub_key.verify(raw_sig, signing_input)``
+      + ``InvalidSignature`` handling).
+
+Layout:
+    - :class:`WebhookVerifier` is the verifier. It takes a ``JWKSCache`` and a
+      replay window; ``verify(request)`` runs the full check chain and raises
+      :class:`~src.errors.WebhookSignatureError` (HTTP 401) on any failure.
+    - :func:`get_webhook_verifier` is the FastAPI dependency — pulls the
+      verifier off ``app.state.webhook_verifier`` (wired in ``create_app``'s
+      lifespan). Wire it via ``Depends(get_webhook_verifier)`` on the route,
+      then ``await verifier.verify(request)``.
+    - :func:`build_webhook_verifier` constructs the verifier + its backing
+      ``JWKSCache`` from a :class:`~src.config.RelayConfig` and an
+      ``httpx.AsyncClient`` (used by the lifespan).
+
+╔══════════════════════════════════════════════════════════════════════════╗
+║  NEEDS-FROM-HB  —  PROVISIONAL CONTRACT (not finalized; do NOT treat as   ║
+║                    settled until HeartBeat publishes the webhook spec).   ║
+╠══════════════════════════════════════════════════════════════════════════╣
+║ Everything below is Relay's *best-guess* placeholder so the receiver is   ║
+║ buildable + testable TODAY. Each item is owned by HeartBeat and MUST be   ║
+║ reconciled before this path is enabled against a real HB producer. The    ║
+║ constants are centralised (module-level) precisely so a one-line change   ║
+║ reconciles each one once HB confirms.                                     ║
+║                                                                           ║
+║ 1. EXACT SIGNING INPUT (the bytes HB feeds to Ed25519.sign).              ║
+║    Provisional: the ASCII bytes of                                        ║
+║        f"{webhook_id}:{timestamp}:{sha256_hex(body)}"                     ║
+║    i.e. ``"<X-HeartBeat-Webhook-Id>:<X-HeartBeat-Timestamp>:"`` followed  ║
+║    by the lowercase hex SHA-256 of the EXACT raw request body bytes.      ║
+║    OPEN: does HB sign the raw body directly (like the old HMAC receiver,  ║
+║    which signed ``f"{ts}.".encode()+body``) or this digest-of-body form?  ║
+║    OPEN: field order, separator char (':' vs '.'), and whether            ║
+║    ``webhook_id`` participates at all.                                    ║
+║                                                                           ║
+║ 2. EXACT HEADER NAMES.                                                    ║
+║    Provisional:                                                           ║
+║        X-HeartBeat-Key-Id     → JWKS ``kid`` of the webhook signing key   ║
+║        X-HeartBeat-Timestamp  → Unix epoch seconds (ASCII int)            ║
+║        X-HeartBeat-Signature  → base64url(Ed25519 signature), no padding  ║
+║        X-HeartBeat-Webhook-Id → opaque per-delivery id (in signing input) ║
+║    OPEN: HB may keep the old ``X-HeartBeat-Signature`` name but DROP the  ║
+║    ``sha256=`` prefix (this scheme has no prefix), may rename Key-Id to   ║
+║    ``X-HeartBeat-Kid``, and may not send a Webhook-Id at all.             ║
+║                                                                           ║
+║ 3. WHERE HB PUBLISHES THE WEBHOOK PUBLIC KEY.                             ║
+║    Provisional: the SAME ``/.well-known/jwks.json`` as the OAuth signer,  ║
+║    distinguished by a distinct ``kid`` and ``use:"sig"`` (so ``jwks_url`` ║
+║    is reused and ``RELAY_WEBHOOK_JWKS_URL`` is left empty).               ║
+║    OPEN: HB may instead expose a DEDICATED webhook-keys endpoint; if so,  ║
+║    set ``RELAY_WEBHOOK_JWKS_URL`` to it (already plumbed in config.py).   ║
+║                                                                           ║
+║ 4. (separate harmonization, NOT this task) the MESSAGE-TYPE CATALOGUE —   ║
+║    what message kinds HB pushes and how Relay dispatches them. The route  ║
+║    below verifies + 200s only; dispatch is a documented TODO there.       ║
+╚══════════════════════════════════════════════════════════════════════════╝
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import time
+from typing import Optional
+
+from cryptography.exceptions import InvalidSignature
+from fastapi import Request
+
+from ..config import RelayConfig
+from ..core.jwks_cache import JWKSCache
+from ..errors import WebhookSignatureError
+
+logger = logging.getLogger(__name__)
+
+
+# ── PROVISIONAL contract constants (see NEEDS-FROM-HB in the module docstring) ──
+#
+# These are the single source of truth for the provisional wire format. When
+# HeartBeat finalizes the webhook signing spec, reconcile by editing HERE.
+
+#: Header carrying the JWKS ``kid`` of the webhook signing key. PROVISIONAL.
+HEADER_KEY_ID = "x-heartbeat-key-id"
+#: Header carrying the Unix-epoch-seconds timestamp (ASCII int). PROVISIONAL.
+HEADER_TIMESTAMP = "x-heartbeat-timestamp"
+#: Header carrying base64url(Ed25519 signature), no padding. PROVISIONAL.
+HEADER_SIGNATURE = "x-heartbeat-signature"
+#: Header carrying the opaque per-delivery webhook id. PROVISIONAL.
+HEADER_WEBHOOK_ID = "x-heartbeat-webhook-id"
+
+
+def _b64url_decode(segment: str) -> bytes:
+    """Decode a base64url segment (issuer may omit padding).
+
+    Modelled on ``src.core.oauth_validator._b64url_decode`` — the same helper
+    the OAuth path uses to decode the JWT signature segment, kept byte-for-byte
+    compatible so both paths agree on the encoding HB emits.
+    """
+    padded = segment + "=" * (-len(segment) % 4)
+    return base64.urlsafe_b64decode(padded.encode("ascii"))
+
+
+def _build_signing_input(webhook_id: str, timestamp: str, body_bytes: bytes) -> bytes:
+    """Reconstruct the exact bytes HeartBeat signed.
+
+    PROVISIONAL (NEEDS-FROM-HB item #1): the ASCII bytes of
+    ``f"{webhook_id}:{timestamp}:{sha256_hex(body)}"``. The body is reduced to
+    its lowercase-hex SHA-256 so the signed message is bounded regardless of
+    payload size; HB MUST sign the identical construction.
+    """
+    body_hash = hashlib.sha256(body_bytes).hexdigest()
+    return f"{webhook_id}:{timestamp}:{body_hash}".encode("ascii")
+
+
+class WebhookVerifier:
+    """Verifies an inbound HeartBeat webhook's **Ed25519** signature.
+
+    The webhook public key is fetched by ``kid`` from HB's published JWKS via
+    the shared :class:`JWKSCache` (no second fetcher). On ANY failure a
+    :class:`WebhookSignatureError` (HTTP 401) is raised — the route lets it
+    bubble to the global ``relay_error_handler``.
+
+    Parameters
+    ----------
+    jwks_cache:
+        Shared :class:`JWKSCache` pointed at HB's webhook-key JWKS URL.
+    replay_window_s:
+        Max allowed absolute skew (seconds) between the signed timestamp and
+        ``now`` before the delivery is rejected as a replay. PROVISIONAL.
+    """
+
+    def __init__(self, jwks_cache: JWKSCache, replay_window_s: int = 300) -> None:
+        self._cache = jwks_cache
+        self._replay_window_s = replay_window_s
+
+    async def verify(self, request: Request) -> None:
+        """Run the full Ed25519 verification chain for one webhook delivery.
+
+        Order (fail-fast, fail-loud — every branch is a 401
+        :class:`WebhookSignatureError`; the client-facing message is generic
+        so a probe cannot distinguish the failure modes):
+
+            1. ``kid`` header present.
+            2. ``timestamp`` header present + integer.
+            3. ``signature`` header present.
+            4. timestamp inside the replay window.
+            5. webhook public key for ``kid`` resolvable from the JWKS.
+            6. signature base64url-decodes.
+            7. Ed25519 verify of the signature over the reconstructed input.
+
+        On success returns ``None`` and the handler runs. Body bytes are read
+        from ``request.state.raw_body`` (populated by ``BodyCacheMiddleware``)
+        so the route can still ``await request.json()`` afterwards; falls back
+        to ``await request.body()`` if the cache middleware did not run.
+        """
+        headers = request.headers
+
+        # ── Step 1: kid header ───────────────────────────────────────────
+        kid = headers.get(HEADER_KEY_ID, "")
+        if not kid:
+            raise WebhookSignatureError(reason="missing key-id header")
+
+        # ── Step 2: timestamp header present + integer ───────────────────
+        timestamp_raw = headers.get(HEADER_TIMESTAMP, "")
+        if not timestamp_raw or not timestamp_raw.lstrip("-").isdigit():
+            raise WebhookSignatureError(reason="missing or non-integer timestamp")
+
+        # ── Step 3: signature header present ─────────────────────────────
+        signature_b64 = headers.get(HEADER_SIGNATURE, "")
+        if not signature_b64:
+            raise WebhookSignatureError(reason="missing signature header")
+
+        # ── Step 4: timestamp inside replay window ───────────────────────
+        timestamp = int(timestamp_raw)
+        now = int(time.time())
+        if abs(now - timestamp) > self._replay_window_s:
+            logger.warning(
+                "Webhook rejected — timestamp %d outside %ds replay window (now=%d).",
+                timestamp, self._replay_window_s, now,
+            )
+            raise WebhookSignatureError(reason="timestamp outside replay window")
+
+        # ── Step 5: resolve webhook public key by kid ────────────────────
+        try:
+            pub_key = await self._cache.get_key(kid)
+        except Exception as exc:
+            # Cold-start JWKS fetch failure — fail closed (401), never admit
+            # an unverified webhook. JWKSCache itself is fail-soft on refresh.
+            logger.warning("Webhook rejected — JWKS fetch failed: %s", exc)
+            raise WebhookSignatureError(reason="jwks fetch failed") from exc
+        if pub_key is None:
+            raise WebhookSignatureError(reason=f"kid={kid!r} not in webhook JWKS")
+
+        # ── Step 6: decode signature ─────────────────────────────────────
+        try:
+            raw_sig = _b64url_decode(signature_b64)
+        except Exception as exc:
+            raise WebhookSignatureError(reason="signature decode failed") from exc
+
+        # ── Step 7: Ed25519 verify over the reconstructed signing input ──
+        webhook_id = headers.get(HEADER_WEBHOOK_ID, "")
+        body_bytes = await self._read_body(request)
+        signing_input = _build_signing_input(webhook_id, timestamp_raw, body_bytes)
+        try:
+            pub_key.verify(raw_sig, signing_input)
+        except InvalidSignature as exc:
+            logger.warning(
+                "Webhook rejected — Ed25519 signature mismatch (kid=%s, ts=%s).",
+                kid, timestamp_raw,
+            )
+            raise WebhookSignatureError(reason="ed25519 signature mismatch") from exc
+        except Exception as exc:
+            raise WebhookSignatureError(
+                reason=f"ed25519 verify error: {exc}"
+            ) from exc
+
+        logger.debug(
+            "Webhook Ed25519 signature verified — kid=%s webhook_id=%s ts=%s",
+            kid, webhook_id or "(none)", timestamp_raw,
+        )
+
+    @staticmethod
+    async def _read_body(request: Request) -> bytes:
+        """Return the raw request body bytes (from the body cache if present)."""
+        body_bytes = getattr(request.state, "raw_body", None)
+        if body_bytes is None:
+            # BodyCacheMiddleware should populate this; if not, read directly
+            # (downstream handler loses idempotency, which is correct on this
+            # failure path).
+            body_bytes = await request.body()
+        return body_bytes
+
+
+def build_webhook_verifier(
+    config: RelayConfig,
+    http_client,  # httpx.AsyncClient — typed loosely to avoid a hard import here
+) -> WebhookVerifier:
+    """Construct a :class:`WebhookVerifier` + its backing :class:`JWKSCache`.
+
+    The JWKS URL is ``RELAY_WEBHOOK_JWKS_URL`` if set, else falls back to the
+    base ``RELAY_JWKS_URL`` (the same-JWKS-distinct-kid hypothesis — see
+    NEEDS-FROM-HB item #3). Called once at startup by ``create_app``'s
+    lifespan with the shared httpx client.
+    """
+    jwks_url = config.webhook_jwks_url or config.jwks_url
+    cache = JWKSCache(jwks_url=jwks_url, http_client=http_client)
+    return WebhookVerifier(cache, replay_window_s=config.webhook_replay_window_s)
+
+
+async def get_webhook_verifier(request: Request) -> WebhookVerifier:
+    """FastAPI dependency — return the app-scoped :class:`WebhookVerifier`.
+
+    Pulls the verifier off ``request.app.state.webhook_verifier`` (wired in
+    the lifespan). Raises a 401 ``WebhookSignatureError`` rather than a 500 if
+    the verifier was never wired, so a misconfigured deploy fails closed on
+    the webhook path instead of admitting traffic.
+    """
+    verifier: Optional[WebhookVerifier] = getattr(
+        request.app.state, "webhook_verifier", None
+    )
+    if verifier is None:
+        logger.error(
+            "Webhook rejected — app.state.webhook_verifier not wired. "
+            "Check create_app lifespan."
+        )
+        raise WebhookSignatureError(reason="webhook verifier not configured")
+    return verifier
+
+
+__all__ = [
+    "WebhookVerifier",
+    "build_webhook_verifier",
+    "get_webhook_verifier",
+    "HEADER_KEY_ID",
+    "HEADER_TIMESTAMP",
+    "HEADER_SIGNATURE",
+    "HEADER_WEBHOOK_ID",
+]

--- a/services/relay/src/config.py
+++ b/services/relay/src/config.py
@@ -73,6 +73,22 @@ class RelayConfig:
     module_cache_refresh_interval_s: int = 43200  # 12 hours
     internal_service_token: str = ""              # For /internal/ auth from HeartBeat
 
+    # ── HeartBeat JWKS (Ed25519 public keys) ─────────────────────────────
+    # Base JWKS endpoint — HeartBeat's OAuth signing keys, served as
+    # OKP/Ed25519 JWKs at /.well-known/jwks.json (RELAY_JWKS_URL).
+    jwks_url: str = "http://localhost:9000/.well-known/jwks.json"
+    # L5 webhook receiver: the public key HeartBeat signs Ed25519 webhooks
+    # with. PROVISIONAL (see webhook_auth.py NEEDS-FROM-HB) — HB has not
+    # finalized whether the webhook signing key is published on the SAME
+    # /.well-known/jwks.json (a distinct ``kid``, ``use:"sig"``) or on a
+    # DEDICATED endpoint. Empty default = fall back to ``jwks_url``
+    # (the same-JWKS-distinct-kid hypothesis). Override with
+    # RELAY_WEBHOOK_JWKS_URL the moment HB publishes a dedicated endpoint.
+    webhook_jwks_url: str = ""
+    # Replay window for webhook timestamps (seconds). PROVISIONAL — HB to
+    # confirm. Mirrors the 300s used by the symmetric receiver this replaces.
+    webhook_replay_window_s: int = 300
+
     # ── Redis (rate limiting) ───────────────────────────────────────────
     redis_url: str = ""                 # Empty = disabled (graceful degradation)
     redis_prefix: str = "relay"
@@ -235,6 +251,14 @@ class RelayConfig:
             kwargs["module_cache_refresh_interval_s"] = int(v)
         if v := env("INTERNAL_SERVICE_TOKEN"):
             kwargs["internal_service_token"] = v
+
+        # ── HeartBeat JWKS (Ed25519)
+        if v := env("JWKS_URL"):
+            kwargs["jwks_url"] = v
+        if v := env("WEBHOOK_JWKS_URL"):
+            kwargs["webhook_jwks_url"] = v
+        if v := env("WEBHOOK_REPLAY_WINDOW_S"):
+            kwargs["webhook_replay_window_s"] = int(v)
 
         # ── Redis
         if v := env("REDIS_URL"):

--- a/services/relay/src/core/jwks_cache.py
+++ b/services/relay/src/core/jwks_cache.py
@@ -104,6 +104,22 @@ class JWKSCache:
             await self._refresh()
         return self._keys.get(kid)
 
+    async def get_all_keys(self) -> list[Ed25519PublicKey]:
+        """
+        Return ALL currently-published Ed25519 public keys.
+
+        Used by the L5 webhook verifier, whose locked contract carries no
+        ``kid`` header — the signature must be tried against every published
+        key (HB publishes one signing key, rarely two during rotation).
+
+        Refreshes the JWKS if the cache is stale OR currently empty (cold
+        start / online rotation). Returns ``[]`` if no Ed25519 keys are
+        available after a refresh (cold start + HTTP down).
+        """
+        if self._is_stale() or not self._keys:
+            await self._refresh()
+        return list(self._keys.values())
+
     async def get_raw_jwk(self, kid: str) -> Optional[Dict[str, Any]]:
         """Return the raw JWK dict for this ``kid`` (for debugging / tests)."""
         if self._is_stale() or kid not in self._raw_jwks:

--- a/services/relay/src/errors.py
+++ b/services/relay/src/errors.py
@@ -180,6 +180,35 @@ class SignatureVerificationFailedError(AuthenticationFailedError):
         super().__init__(message="HMAC signature verification failed.")
 
 
+class WebhookSignatureError(AuthenticationFailedError):
+    """
+    Inbound HeartBeat webhook failed Ed25519 signature verification (L5).
+
+    Raised by :class:`~src.api.webhook_auth.WebhookVerifier` for every
+    rejection on the webhook receive path: missing/malformed headers,
+    unknown ``kid`` (no published webhook key matches), expired timestamp
+    (replay window), tampered body, or a bad signature. Subclasses
+    :class:`AuthenticationFailedError`, so it maps to HTTP **401** with
+    ``error_code="AUTHENTICATION_FAILED"`` via the global
+    ``relay_error_handler`` — no extra handler wiring.
+
+    This REPLACES the symmetric-HMAC ``WebhookAuthError`` (3-header
+    ``sha256=`` shared-secret scheme) per the ARCH "Bob ratification pass"
+    2026-06-19 (ledger L5), which reversed the earlier symmetric ruling.
+    HeartBeat now SIGNS webhooks with Ed25519 (reusing its OAuth JWKS
+    Ed25519 infra); Relay VERIFIES against HB's published webhook public
+    key. There is intentionally no symmetric code path.
+
+    The ``reason`` is kept on the exception for structured logging /
+    metrics; the client-facing ``message`` is deliberately generic so a
+    probe cannot distinguish "unknown kid" from "bad signature".
+    """
+
+    def __init__(self, reason: str = "Webhook signature verification failed"):
+        super().__init__(message="Webhook signature verification failed.")
+        self.reason = reason
+
+
 class TimestampExpiredError(AuthenticationFailedError):
     """Request timestamp outside the 5-minute window."""
 

--- a/services/relay/tests/api/test_webhook_auth.py
+++ b/services/relay/tests/api/test_webhook_auth.py
@@ -1,0 +1,470 @@
+"""
+Tests for the L5 Ed25519 webhook receiver (``src.api.webhook_auth``).
+
+HeartBeat signs webhooks with **Ed25519** (reusing its OAuth JWKS infra +
+a published webhook public key); Relay VERIFIES against that key fetched by
+``kid`` via :class:`JWKSCache`. This file is a FRESH rewrite — the old
+symmetric-HMAC (``sha256=`` shared-secret) tests are intentionally gone, per
+the ARCH "Bob ratification pass" 2026-06-19 (ledger L5) that reversed the
+symmetric ruling.
+
+These tests exercise verification WITHOUT any real HeartBeat or JWKS HTTP
+server: an Ed25519 keypair is generated in-process via ``cryptography`` and
+served through a stub :class:`JWKSCache` (modelled on
+``tests/core/test_oauth_validator.py``).
+
+Coverage:
+- valid signature accepted
+- tampered body rejected
+- wrong-kid rejected
+- wrong-key (kid present but different keypair) rejected
+- missing signature header rejected
+- missing kid header rejected
+- missing/non-integer timestamp rejected
+- expired timestamp (outside replay window) rejected
+- route POST /api/webhook: 200 on valid, 401 on bad signature
+- structural assertion: NO symmetric-HMAC code path exists in the module
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import inspect
+import time
+from typing import Any, Dict, Optional
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from starlette.datastructures import Headers
+
+import src.api.webhook_auth as webhook_auth
+from src.api.webhook_auth import (
+    HEADER_KEY_ID,
+    HEADER_SIGNATURE,
+    HEADER_TIMESTAMP,
+    HEADER_WEBHOOK_ID,
+    WebhookVerifier,
+)
+from src.core.jwks_cache import JWKSCache
+from src.errors import WebhookSignatureError
+
+
+# ── Ed25519 test-key factory ──────────────────────────────────────────────
+
+
+def _generate_keypair():
+    private_key = Ed25519PrivateKey.generate()
+    return private_key, private_key.public_key()
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _signing_input(webhook_id: str, timestamp: str, body: bytes) -> bytes:
+    """Mirror of ``webhook_auth._build_signing_input`` — the bytes HB signs.
+
+    PROVISIONAL (NEEDS-FROM-HB #1): ``"{webhook_id}:{timestamp}:{sha256_hex(body)}"``.
+    Kept independent here so a drift in the production helper is caught.
+    """
+    body_hash = hashlib.sha256(body).hexdigest()
+    return f"{webhook_id}:{timestamp}:{body_hash}".encode("ascii")
+
+
+def _sign(
+    private_key: Ed25519PrivateKey,
+    *,
+    webhook_id: str,
+    timestamp: str,
+    body: bytes,
+) -> str:
+    """Produce the base64url Ed25519 signature HB would send."""
+    sig = private_key.sign(_signing_input(webhook_id, timestamp, body))
+    return _b64url(sig)
+
+
+# ── JWKSCache stub (in-memory, no HTTP) ───────────────────────────────────
+
+
+class _StubJWKSCache(JWKSCache):
+    """Serves Ed25519 public keys from an in-memory ``kid -> key`` dict.
+
+    Bypasses ``JWKSCache.__init__`` and overrides ``get_key`` entirely, exactly
+    like the OAuth validator tests' stub — so no httpx client is constructed.
+    """
+
+    def __init__(self, keys: Dict[str, Ed25519PublicKey]):
+        self._key_map = keys
+
+    async def get_key(self, kid: str) -> Optional[Ed25519PublicKey]:
+        return self._key_map.get(kid)
+
+
+# ── Minimal fake Request ──────────────────────────────────────────────────
+
+
+class _FakeState:
+    pass
+
+
+class _FakeRequest:
+    """Just enough of ``starlette.requests.Request`` for the verifier.
+
+    Exposes a case-insensitive ``.headers`` (real Starlette ``Headers``),
+    a ``.state`` carrying ``raw_body``, and an async ``.body()`` fallback.
+    """
+
+    def __init__(self, headers: Dict[str, str], body: bytes):
+        # Starlette Headers is case-insensitive, matching a real request.
+        self.headers = Headers(headers)
+        self.state = _FakeState()
+        self.state.raw_body = body
+        self._body = body
+
+    async def body(self) -> bytes:
+        return self._body
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+KID = "hb-webhook-key-1"
+
+
+@pytest.fixture
+def keypair():
+    return _generate_keypair()
+
+
+@pytest.fixture
+def private_key(keypair):
+    return keypair[0]
+
+
+@pytest.fixture
+def public_key(keypair):
+    return keypair[1]
+
+
+@pytest.fixture
+def jwks_cache(public_key):
+    """Stub cache with one valid Ed25519 webhook key under KID."""
+    return _StubJWKSCache({KID: public_key})
+
+
+@pytest.fixture
+def verifier(jwks_cache):
+    return WebhookVerifier(jwks_cache, replay_window_s=300)
+
+
+def _make_request(
+    private_key: Ed25519PrivateKey,
+    *,
+    body: bytes = b'{"event": "ping"}',
+    webhook_id: str = "wh-001",
+    kid: str = KID,
+    timestamp: Optional[str] = None,
+    signature: Optional[str] = None,
+    omit: Optional[set] = None,
+) -> _FakeRequest:
+    """Build a fully-signed fake webhook request, with knobs for negatives."""
+    omit = omit or set()
+    if timestamp is None:
+        timestamp = str(int(time.time()))
+    if signature is None:
+        signature = _sign(
+            private_key, webhook_id=webhook_id, timestamp=timestamp, body=body
+        )
+    headers: Dict[str, str] = {}
+    if HEADER_KEY_ID not in omit:
+        headers[HEADER_KEY_ID] = kid
+    if HEADER_TIMESTAMP not in omit:
+        headers[HEADER_TIMESTAMP] = timestamp
+    if HEADER_SIGNATURE not in omit:
+        headers[HEADER_SIGNATURE] = signature
+    if HEADER_WEBHOOK_ID not in omit:
+        headers[HEADER_WEBHOOK_ID] = webhook_id
+    return _FakeRequest(headers, body)
+
+
+# ── Valid path ─────────────────────────────────────────────────────────────
+
+
+class TestValidSignature:
+    @pytest.mark.asyncio
+    async def test_valid_signature_accepted(self, verifier, private_key):
+        request = _make_request(private_key)
+        # Returns None and does not raise.
+        assert await verifier.verify(request) is None
+
+    @pytest.mark.asyncio
+    async def test_valid_signature_no_webhook_id(self, verifier, private_key):
+        """webhook_id is optional in the provisional contract — empty is fine
+        as long as both sides agree (signing input uses '')."""
+        request = _make_request(private_key, webhook_id="")
+        assert await verifier.verify(request) is None
+
+    @pytest.mark.asyncio
+    async def test_kid_header_is_case_insensitive(self, verifier, private_key):
+        """HTTP headers are case-insensitive — an upper-cased kid still works."""
+        ts = str(int(time.time()))
+        body = b'{"event": "ping"}'
+        sig = _sign(private_key, webhook_id="wh-001", timestamp=ts, body=body)
+        request = _FakeRequest(
+            {
+                "X-HeartBeat-Key-Id": KID,
+                "X-HeartBeat-Timestamp": ts,
+                "X-HeartBeat-Signature": sig,
+                "X-HeartBeat-Webhook-Id": "wh-001",
+            },
+            body,
+        )
+        assert await verifier.verify(request) is None
+
+
+# ── Rejections ──────────────────────────────────────────────────────────────
+
+
+class TestRejections:
+    @pytest.mark.asyncio
+    async def test_tampered_body_rejected(self, verifier, private_key):
+        request = _make_request(private_key, body=b'{"event": "ping"}')
+        # Swap the body AFTER signing — signature now covers the wrong digest.
+        request.state.raw_body = b'{"event": "TAMPERED"}'
+        request._body = b'{"event": "TAMPERED"}'
+        with pytest.raises(WebhookSignatureError):
+            await verifier.verify(request)
+
+    @pytest.mark.asyncio
+    async def test_wrong_kid_rejected(self, verifier, private_key):
+        """kid not present in the JWKS → reject (no key to verify against)."""
+        request = _make_request(private_key, kid="unknown-kid")
+        with pytest.raises(WebhookSignatureError):
+            await verifier.verify(request)
+
+    @pytest.mark.asyncio
+    async def test_wrong_key_rejected(self, verifier):
+        """kid resolves, but the delivery was signed by a DIFFERENT keypair."""
+        attacker_key, _ = _generate_keypair()
+        request = _make_request(attacker_key)  # signs with the wrong key, KID header
+        with pytest.raises(WebhookSignatureError):
+            await verifier.verify(request)
+
+    @pytest.mark.asyncio
+    async def test_missing_signature_rejected(self, verifier, private_key):
+        request = _make_request(private_key, omit={HEADER_SIGNATURE})
+        with pytest.raises(WebhookSignatureError):
+            await verifier.verify(request)
+
+    @pytest.mark.asyncio
+    async def test_missing_kid_rejected(self, verifier, private_key):
+        request = _make_request(private_key, omit={HEADER_KEY_ID})
+        with pytest.raises(WebhookSignatureError):
+            await verifier.verify(request)
+
+    @pytest.mark.asyncio
+    async def test_missing_timestamp_rejected(self, verifier, private_key):
+        request = _make_request(private_key, omit={HEADER_TIMESTAMP})
+        with pytest.raises(WebhookSignatureError):
+            await verifier.verify(request)
+
+    @pytest.mark.asyncio
+    async def test_non_integer_timestamp_rejected(self, verifier, private_key):
+        request = _make_request(private_key, timestamp="not-a-number")
+        with pytest.raises(WebhookSignatureError):
+            await verifier.verify(request)
+
+    @pytest.mark.asyncio
+    async def test_expired_timestamp_rejected(self, verifier, private_key):
+        """Timestamp older than the 300s replay window → reject (even though
+        the signature over that old timestamp is itself valid)."""
+        old_ts = str(int(time.time()) - 3600)  # 1 hour ago
+        request = _make_request(private_key, timestamp=old_ts)
+        with pytest.raises(WebhookSignatureError):
+            await verifier.verify(request)
+
+    @pytest.mark.asyncio
+    async def test_future_timestamp_rejected(self, verifier, private_key):
+        """Far-future timestamp is also outside the window (abs skew)."""
+        future_ts = str(int(time.time()) + 3600)
+        request = _make_request(private_key, timestamp=future_ts)
+        with pytest.raises(WebhookSignatureError):
+            await verifier.verify(request)
+
+    @pytest.mark.asyncio
+    async def test_malformed_signature_rejected(self, verifier, private_key):
+        """A signature that base64url-decodes but is the wrong length / bytes."""
+        request = _make_request(private_key, signature=_b64url(b"too-short"))
+        with pytest.raises(WebhookSignatureError):
+            await verifier.verify(request)
+
+
+# ── Dependency wiring ──────────────────────────────────────────────────────
+
+
+class TestDependency:
+    @pytest.mark.asyncio
+    async def test_unwired_verifier_fails_closed(self):
+        """get_webhook_verifier raises 401 (not 500) if state is unwired."""
+        from src.api.webhook_auth import get_webhook_verifier
+
+        class _App:
+            class state:  # noqa: N801 - mimic app.state attribute access
+                pass
+
+        class _Req:
+            app = _App()
+
+        with pytest.raises(WebhookSignatureError):
+            await get_webhook_verifier(_Req())
+
+
+# ── Route: POST /api/webhook via the full app ──────────────────────────────
+
+
+@pytest.fixture
+def test_config():
+    from src.config import RelayConfig
+
+    return RelayConfig(
+        host="127.0.0.1",
+        port=8082,
+        instance_id="relay-test",
+        require_encryption=False,
+        # HMAC s2s migration: non-empty signing key required for the
+        # HeartBeatClient calls the lifespan makes at startup.
+        heartbeat_api_key="test-relay-key",
+        heartbeat_s2s_signing_key="0123456789abcdef" * 4,
+    )
+
+
+@pytest.fixture
+async def route_client(test_config, jwks_cache):
+    """App client with the stub JWKSCache-backed verifier injected.
+
+    The real lifespan builds a verifier pointed at the (unreachable) JWKS URL;
+    we override ``app.state.webhook_verifier`` with one backed by the in-memory
+    stub so the route can verify a real in-test signature.
+    """
+    from asgi_lifespan import LifespanManager
+    from httpx import ASGITransport, AsyncClient
+
+    from src.api.app import create_app
+
+    app = create_app(config=test_config, api_key_secrets={})
+    async with LifespanManager(app):
+        app.state.webhook_verifier = WebhookVerifier(jwks_cache, replay_window_s=300)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            yield c
+
+
+class TestWebhookRoute:
+    @pytest.mark.asyncio
+    async def test_route_accepts_valid_signature(self, route_client, private_key):
+        body = b'{"event": "config_changed"}'
+        ts = str(int(time.time()))
+        sig = _sign(private_key, webhook_id="wh-77", timestamp=ts, body=body)
+        resp = await route_client.post(
+            "/api/webhook",
+            content=body,
+            headers={
+                HEADER_KEY_ID: KID,
+                HEADER_TIMESTAMP: ts,
+                HEADER_SIGNATURE: sig,
+                HEADER_WEBHOOK_ID: "wh-77",
+                "content-type": "application/json",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_route_rejects_bad_signature(self, route_client, private_key):
+        body = b'{"event": "config_changed"}'
+        ts = str(int(time.time()))
+        sig = _sign(private_key, webhook_id="wh-77", timestamp=ts, body=body)
+        resp = await route_client.post(
+            "/api/webhook",
+            content=b'{"event": "TAMPERED"}',  # body differs from what was signed
+            headers={
+                HEADER_KEY_ID: KID,
+                HEADER_TIMESTAMP: ts,
+                HEADER_SIGNATURE: sig,
+                HEADER_WEBHOOK_ID: "wh-77",
+                "content-type": "application/json",
+            },
+        )
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_route_rejects_missing_headers(self, route_client):
+        resp = await route_client.post(
+            "/api/webhook",
+            content=b'{"event": "x"}',
+            headers={"content-type": "application/json"},
+        )
+        assert resp.status_code == 401
+
+
+# ── Structural guard: NO symmetric-HMAC path exists ────────────────────────
+
+
+def _executable_code_only(module) -> str:
+    """Return module source with all comments AND string-literals removed.
+
+    Docstrings/comments in this module legitimately *describe* the old
+    symmetric scheme they replace (NEEDS-FROM-HB cross-references it), so a
+    naive substring scan over raw source would false-positive. We tokenize and
+    drop COMMENT + STRING tokens, leaving only real executable code — which is
+    where a symmetric-HMAC *code path* would actually live.
+    """
+    import io
+    import tokenize
+
+    src = inspect.getsource(module)
+    out: list[str] = []
+    for tok in tokenize.generate_tokens(io.StringIO(src).readline):
+        if tok.type in (tokenize.COMMENT, tokenize.STRING):
+            continue
+        # NL/NEWLINE/INDENT carry no identifiers — keep names + operators.
+        out.append(tok.string)
+    return " ".join(out).lower()
+
+
+class TestNoSymmetricHmacPath:
+    """Lock in the L5 ruling: the receiver is asymmetric-only.
+
+    These scan EXECUTABLE CODE (comments + docstrings stripped) so they assert
+    the absence of a symmetric *code path*, not the absence of the words in
+    explanatory prose (which intentionally references the scheme it replaced).
+    """
+
+    def test_module_has_no_symmetric_hmac_code(self):
+        code = _executable_code_only(webhook_auth)
+        # No HMAC primitive, no shared-secret comparison, no shared-secret config.
+        assert "hmac" not in code            # no `import hmac`, no `hmac.new(...)`
+        assert "compare_digest" not in code  # no constant-time secret compare
+        assert "webhook_signing_key" not in code  # no shared-secret config field
+        # The asymmetric primitive IS present in real code.
+        source = inspect.getsource(webhook_auth)
+        assert ".verify(" in source          # Ed25519 public-key verify
+        assert "InvalidSignature" in source
+
+    def test_route_module_has_no_symmetric_hmac_code(self):
+        import src.api.routes.webhook as webhook_route
+
+        code = _executable_code_only(webhook_route)
+        assert "hmac" not in code
+        assert "compare_digest" not in code
+        assert "webhook_signing_key" not in code
+
+    def test_no_symmetric_webhook_auth_error_symbol(self):
+        """The old symmetric error type must not exist in errors."""
+        import src.errors as errors
+
+        assert not hasattr(errors, "WebhookAuthError")
+        assert hasattr(errors, "WebhookSignatureError")

--- a/services/relay/tests/api/test_webhook_auth.py
+++ b/services/relay/tests/api/test_webhook_auth.py
@@ -1,9 +1,11 @@
 """
 Tests for the L5 Ed25519 webhook receiver (``src.api.webhook_auth``).
 
-HeartBeat signs webhooks with **Ed25519** (reusing its OAuth JWKS infra +
-a published webhook public key); Relay VERIFIES against that key fetched by
-``kid`` via :class:`JWKSCache`. This file is a FRESH rewrite — the old
+HeartBeat signs webhooks with **Ed25519** (reusing the SAME Ed25519 key it
+publishes on its OAuth JWKS); Relay VERIFIES against the published key(s)
+fetched via :class:`JWKSCache`. The locked contract (CONTRACT_LEDGER L5,
+2026-06-20) carries NO kid header — verification is tried against every
+published key. This file is a FRESH rewrite to the LOCKED contract — the old
 symmetric-HMAC (``sha256=`` shared-secret) tests are intentionally gone, per
 the ARCH "Bob ratification pass" 2026-06-19 (ledger L5) that reversed the
 symmetric ruling.
@@ -13,15 +15,22 @@ server: an Ed25519 keypair is generated in-process via ``cryptography`` and
 served through a stub :class:`JWKSCache` (modelled on
 ``tests/core/test_oauth_validator.py``).
 
+LOCKED contract under test:
+- signing input = ``f"{unix_ts}.".encode("utf-8") + raw_body_bytes``
+- header ``X-HeartBeat-Signature: ed25519=<standard base64(sig)>``
+- header ``X-HeartBeat-Timestamp: <unix epoch seconds>``
+- replay window 300s absolute skew
+- NO kid header, NO webhook-id header
+
 Coverage:
 - valid signature accepted
 - tampered body rejected
-- wrong-kid rejected
-- wrong-key (kid present but different keypair) rejected
+- wrong-key (signed by a different keypair) rejected
 - missing signature header rejected
-- missing kid header rejected
+- signature header without ``ed25519=`` prefix rejected
 - missing/non-integer timestamp rejected
 - expired timestamp (outside replay window) rejected
+- key rotation: verifies against whichever of multiple published keys signed
 - route POST /api/webhook: 200 on valid, 401 on bad signature
 - structural assertion: NO symmetric-HMAC code path exists in the module
 """
@@ -29,10 +38,9 @@ Coverage:
 from __future__ import annotations
 
 import base64
-import hashlib
 import inspect
 import time
-from typing import Any, Dict, Optional
+from typing import Dict, List, Optional
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (
@@ -43,10 +51,9 @@ from starlette.datastructures import Headers
 
 import src.api.webhook_auth as webhook_auth
 from src.api.webhook_auth import (
-    HEADER_KEY_ID,
     HEADER_SIGNATURE,
     HEADER_TIMESTAMP,
-    HEADER_WEBHOOK_ID,
+    SIGNATURE_SCHEME_PREFIX,
     WebhookVerifier,
 )
 from src.core.jwks_cache import JWKSCache
@@ -61,47 +68,37 @@ def _generate_keypair():
     return private_key, private_key.public_key()
 
 
-def _b64url(data: bytes) -> str:
-    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
-
-
-def _signing_input(webhook_id: str, timestamp: str, body: bytes) -> bytes:
+def _signing_input(timestamp: str, body: bytes) -> bytes:
     """Mirror of ``webhook_auth._build_signing_input`` — the bytes HB signs.
 
-    PROVISIONAL (NEEDS-FROM-HB #1): ``"{webhook_id}:{timestamp}:{sha256_hex(body)}"``.
+    LOCKED (CONTRACT_LEDGER L5): ``f"{timestamp}.".encode("utf-8") + body``.
     Kept independent here so a drift in the production helper is caught.
     """
-    body_hash = hashlib.sha256(body).hexdigest()
-    return f"{webhook_id}:{timestamp}:{body_hash}".encode("ascii")
+    return f"{timestamp}.".encode("utf-8") + body
 
 
-def _sign(
-    private_key: Ed25519PrivateKey,
-    *,
-    webhook_id: str,
-    timestamp: str,
-    body: bytes,
-) -> str:
-    """Produce the base64url Ed25519 signature HB would send."""
-    sig = private_key.sign(_signing_input(webhook_id, timestamp, body))
-    return _b64url(sig)
+def _sign(private_key: Ed25519PrivateKey, *, timestamp: str, body: bytes) -> str:
+    """Produce the ``ed25519=<standard base64>`` header value HB would send."""
+    sig = private_key.sign(_signing_input(timestamp, body))
+    return SIGNATURE_SCHEME_PREFIX + base64.b64encode(sig).decode("ascii")
 
 
 # ── JWKSCache stub (in-memory, no HTTP) ───────────────────────────────────
 
 
 class _StubJWKSCache(JWKSCache):
-    """Serves Ed25519 public keys from an in-memory ``kid -> key`` dict.
+    """Serves Ed25519 public keys from an in-memory list.
 
-    Bypasses ``JWKSCache.__init__`` and overrides ``get_key`` entirely, exactly
-    like the OAuth validator tests' stub — so no httpx client is constructed.
+    Bypasses ``JWKSCache.__init__`` and overrides ``get_all_keys`` (the L5
+    no-kid resolution entrypoint) entirely, like the OAuth validator tests'
+    stub — so no httpx client is constructed.
     """
 
-    def __init__(self, keys: Dict[str, Ed25519PublicKey]):
-        self._key_map = keys
+    def __init__(self, keys: List[Ed25519PublicKey]):
+        self._key_list = list(keys)
 
-    async def get_key(self, kid: str) -> Optional[Ed25519PublicKey]:
-        return self._key_map.get(kid)
+    async def get_all_keys(self) -> List[Ed25519PublicKey]:
+        return list(self._key_list)
 
 
 # ── Minimal fake Request ──────────────────────────────────────────────────
@@ -131,8 +128,6 @@ class _FakeRequest:
 
 # ── Fixtures ──────────────────────────────────────────────────────────────
 
-KID = "hb-webhook-key-1"
-
 
 @pytest.fixture
 def keypair():
@@ -151,8 +146,8 @@ def public_key(keypair):
 
 @pytest.fixture
 def jwks_cache(public_key):
-    """Stub cache with one valid Ed25519 webhook key under KID."""
-    return _StubJWKSCache({KID: public_key})
+    """Stub cache with one valid Ed25519 webhook key published."""
+    return _StubJWKSCache([public_key])
 
 
 @pytest.fixture
@@ -164,8 +159,6 @@ def _make_request(
     private_key: Ed25519PrivateKey,
     *,
     body: bytes = b'{"event": "ping"}',
-    webhook_id: str = "wh-001",
-    kid: str = KID,
     timestamp: Optional[str] = None,
     signature: Optional[str] = None,
     omit: Optional[set] = None,
@@ -175,18 +168,12 @@ def _make_request(
     if timestamp is None:
         timestamp = str(int(time.time()))
     if signature is None:
-        signature = _sign(
-            private_key, webhook_id=webhook_id, timestamp=timestamp, body=body
-        )
+        signature = _sign(private_key, timestamp=timestamp, body=body)
     headers: Dict[str, str] = {}
-    if HEADER_KEY_ID not in omit:
-        headers[HEADER_KEY_ID] = kid
     if HEADER_TIMESTAMP not in omit:
         headers[HEADER_TIMESTAMP] = timestamp
     if HEADER_SIGNATURE not in omit:
         headers[HEADER_SIGNATURE] = signature
-    if HEADER_WEBHOOK_ID not in omit:
-        headers[HEADER_WEBHOOK_ID] = webhook_id
     return _FakeRequest(headers, body)
 
 
@@ -201,28 +188,51 @@ class TestValidSignature:
         assert await verifier.verify(request) is None
 
     @pytest.mark.asyncio
-    async def test_valid_signature_no_webhook_id(self, verifier, private_key):
-        """webhook_id is optional in the provisional contract — empty is fine
-        as long as both sides agree (signing input uses '')."""
-        request = _make_request(private_key, webhook_id="")
-        assert await verifier.verify(request) is None
-
-    @pytest.mark.asyncio
-    async def test_kid_header_is_case_insensitive(self, verifier, private_key):
-        """HTTP headers are case-insensitive — an upper-cased kid still works."""
+    async def test_headers_are_case_insensitive(self, verifier, private_key):
+        """HTTP headers are case-insensitive — canonical-cased names still work."""
         ts = str(int(time.time()))
         body = b'{"event": "ping"}'
-        sig = _sign(private_key, webhook_id="wh-001", timestamp=ts, body=body)
+        sig = _sign(private_key, timestamp=ts, body=body)
         request = _FakeRequest(
             {
-                "X-HeartBeat-Key-Id": KID,
                 "X-HeartBeat-Timestamp": ts,
                 "X-HeartBeat-Signature": sig,
-                "X-HeartBeat-Webhook-Id": "wh-001",
             },
             body,
         )
         assert await verifier.verify(request) is None
+
+    @pytest.mark.asyncio
+    async def test_empty_body_signature_accepted(self, verifier, private_key):
+        """An empty raw body is a valid signing input (``f"{ts}." + b"")``."""
+        request = _make_request(private_key, body=b"")
+        assert await verifier.verify(request) is None
+
+
+# ── Key rotation: multiple published keys ──────────────────────────────────
+
+
+class TestKeyRotation:
+    @pytest.mark.asyncio
+    async def test_verifies_against_second_published_key(self):
+        """HB publishes two keys during rotation; the delivery is signed by the
+        SECOND one. The verifier must try every published key and accept."""
+        old_priv, old_pub = _generate_keypair()
+        new_priv, new_pub = _generate_keypair()
+        cache = _StubJWKSCache([old_pub, new_pub])
+        verifier = WebhookVerifier(cache, replay_window_s=300)
+
+        # Sign with the NEW key (second in the published set).
+        request = _make_request(new_priv)
+        assert await verifier.verify(request) is None
+
+    @pytest.mark.asyncio
+    async def test_no_published_keys_rejected(self, private_key):
+        """Empty JWKS (no Ed25519 keys at all) → reject, fail closed."""
+        verifier = WebhookVerifier(_StubJWKSCache([]), replay_window_s=300)
+        request = _make_request(private_key)
+        with pytest.raises(WebhookSignatureError):
+            await verifier.verify(request)
 
 
 # ── Rejections ──────────────────────────────────────────────────────────────
@@ -232,24 +242,17 @@ class TestRejections:
     @pytest.mark.asyncio
     async def test_tampered_body_rejected(self, verifier, private_key):
         request = _make_request(private_key, body=b'{"event": "ping"}')
-        # Swap the body AFTER signing — signature now covers the wrong digest.
+        # Swap the body AFTER signing — signature now covers different bytes.
         request.state.raw_body = b'{"event": "TAMPERED"}'
         request._body = b'{"event": "TAMPERED"}'
         with pytest.raises(WebhookSignatureError):
             await verifier.verify(request)
 
     @pytest.mark.asyncio
-    async def test_wrong_kid_rejected(self, verifier, private_key):
-        """kid not present in the JWKS → reject (no key to verify against)."""
-        request = _make_request(private_key, kid="unknown-kid")
-        with pytest.raises(WebhookSignatureError):
-            await verifier.verify(request)
-
-    @pytest.mark.asyncio
     async def test_wrong_key_rejected(self, verifier):
-        """kid resolves, but the delivery was signed by a DIFFERENT keypair."""
+        """The delivery was signed by a key NOT in the published JWKS."""
         attacker_key, _ = _generate_keypair()
-        request = _make_request(attacker_key)  # signs with the wrong key, KID header
+        request = _make_request(attacker_key)  # signs with a key not published
         with pytest.raises(WebhookSignatureError):
             await verifier.verify(request)
 
@@ -260,8 +263,34 @@ class TestRejections:
             await verifier.verify(request)
 
     @pytest.mark.asyncio
-    async def test_missing_kid_rejected(self, verifier, private_key):
-        request = _make_request(private_key, omit={HEADER_KEY_ID})
+    async def test_signature_without_ed25519_prefix_rejected(
+        self, verifier, private_key
+    ):
+        """A signature header missing the ``ed25519=`` scheme prefix → reject.
+
+        The value below is a perfectly valid base64 signature but lacks the
+        mandated prefix, so it must be refused before any verify attempt.
+        """
+        ts = str(int(time.time()))
+        body = b'{"event": "ping"}'
+        raw_sig = private_key.sign(_signing_input(ts, body))
+        bare_b64 = base64.b64encode(raw_sig).decode("ascii")  # no ed25519= prefix
+        request = _FakeRequest(
+            {HEADER_TIMESTAMP: ts, HEADER_SIGNATURE: bare_b64}, body
+        )
+        with pytest.raises(WebhookSignatureError):
+            await verifier.verify(request)
+
+    @pytest.mark.asyncio
+    async def test_wrong_scheme_prefix_rejected(self, verifier, private_key):
+        """An ``hmac-sha256=`` (or any non-``ed25519=``) prefix → reject."""
+        ts = str(int(time.time()))
+        body = b'{"event": "ping"}'
+        raw_sig = private_key.sign(_signing_input(ts, body))
+        wrong = "hmac-sha256=" + base64.b64encode(raw_sig).decode("ascii")
+        request = _FakeRequest(
+            {HEADER_TIMESTAMP: ts, HEADER_SIGNATURE: wrong}, body
+        )
         with pytest.raises(WebhookSignatureError):
             await verifier.verify(request)
 
@@ -296,8 +325,25 @@ class TestRejections:
 
     @pytest.mark.asyncio
     async def test_malformed_signature_rejected(self, verifier, private_key):
-        """A signature that base64url-decodes but is the wrong length / bytes."""
-        request = _make_request(private_key, signature=_b64url(b"too-short"))
+        """A signature with the right prefix but the wrong length / bytes."""
+        ts = str(int(time.time()))
+        body = b'{"event": "ping"}'
+        bad = SIGNATURE_SCHEME_PREFIX + base64.b64encode(b"too-short").decode("ascii")
+        request = _FakeRequest(
+            {HEADER_TIMESTAMP: ts, HEADER_SIGNATURE: bad}, body
+        )
+        with pytest.raises(WebhookSignatureError):
+            await verifier.verify(request)
+
+    @pytest.mark.asyncio
+    async def test_non_base64_signature_rejected(self, verifier, private_key):
+        """``ed25519=`` prefix present but the remainder is not valid base64."""
+        ts = str(int(time.time()))
+        body = b'{"event": "ping"}'
+        bad = SIGNATURE_SCHEME_PREFIX + "!!!not base64!!!"
+        request = _FakeRequest(
+            {HEADER_TIMESTAMP: ts, HEADER_SIGNATURE: bad}, body
+        )
         with pytest.raises(WebhookSignatureError):
             await verifier.verify(request)
 
@@ -367,15 +413,13 @@ class TestWebhookRoute:
     async def test_route_accepts_valid_signature(self, route_client, private_key):
         body = b'{"event": "config_changed"}'
         ts = str(int(time.time()))
-        sig = _sign(private_key, webhook_id="wh-77", timestamp=ts, body=body)
+        sig = _sign(private_key, timestamp=ts, body=body)
         resp = await route_client.post(
             "/api/webhook",
             content=body,
             headers={
-                HEADER_KEY_ID: KID,
                 HEADER_TIMESTAMP: ts,
                 HEADER_SIGNATURE: sig,
-                HEADER_WEBHOOK_ID: "wh-77",
                 "content-type": "application/json",
             },
         )
@@ -386,15 +430,13 @@ class TestWebhookRoute:
     async def test_route_rejects_bad_signature(self, route_client, private_key):
         body = b'{"event": "config_changed"}'
         ts = str(int(time.time()))
-        sig = _sign(private_key, webhook_id="wh-77", timestamp=ts, body=body)
+        sig = _sign(private_key, timestamp=ts, body=body)
         resp = await route_client.post(
             "/api/webhook",
             content=b'{"event": "TAMPERED"}',  # body differs from what was signed
             headers={
-                HEADER_KEY_ID: KID,
                 HEADER_TIMESTAMP: ts,
                 HEADER_SIGNATURE: sig,
-                HEADER_WEBHOOK_ID: "wh-77",
                 "content-type": "application/json",
             },
         )
@@ -417,10 +459,10 @@ def _executable_code_only(module) -> str:
     """Return module source with all comments AND string-literals removed.
 
     Docstrings/comments in this module legitimately *describe* the old
-    symmetric scheme they replace (NEEDS-FROM-HB cross-references it), so a
-    naive substring scan over raw source would false-positive. We tokenize and
-    drop COMMENT + STRING tokens, leaving only real executable code — which is
-    where a symmetric-HMAC *code path* would actually live.
+    symmetric scheme they replace, so a naive substring scan over raw source
+    would false-positive. We tokenize and drop COMMENT + STRING tokens,
+    leaving only real executable code — which is where a symmetric-HMAC *code
+    path* would actually live.
     """
     import io
     import tokenize


### PR DESCRIPTION
ARCH tick62 SHA-pinned MERGE-GO (was f2a494e; rebased on post-#29 main -> 5eec75f for the jwks de-dup, re-vet per ARCH rule). LOCKED L5 Ed25519: signing input {unix_ts}.+raw_body; headers X-HeartBeat-Timestamp + X-HeartBeat-Signature: ed25519=<b64>; JWKS no-kid (verifier iterates get_all_keys); 5-min replay; zero symmetric-HMAC path. De-dup vs #29: vendored jwks_cache/oauth_validator collapsed into #29's canonical; get_all_keys() added to the canonical jwks_cache (serves both #29 OAuth get_key + webhook get_all_keys). 867 tests / 7 pre-existing. Supersedes draft #22.